### PR TITLE
Improve builder methods

### DIFF
--- a/src/main/java/ai/chalk/models/OnlineQueryParams.java
+++ b/src/main/java/ai/chalk/models/OnlineQueryParams.java
@@ -151,6 +151,7 @@ public class OnlineQueryParams {
             return (T) this._withOutputs(outputFqns);
         }
 
+        // withStaleness takes a map of feature FQN to duration and adds them to the staleness map
         public T withStaleness(Map<String, Duration> staleness) {
             if (this.staleness == null) {
                 this.staleness = new HashMap<>();
@@ -168,7 +169,7 @@ public class OnlineQueryParams {
             return (T) this;
         }
 
-        // withTags takes either multiple arguments or a single list of tags and adds them to the tags list
+        // withTags takes a List of tags and adds them to the tags list
         public T withTags(List<String> tags) {
             if (this.tags == null) {
                 this.tags = new ArrayList<>();
@@ -177,9 +178,14 @@ public class OnlineQueryParams {
             return (T) this;
         }
 
+        // withTags takes a one or more tags and adds them to the tags list
+        public T withTags(String... tags) {
+            return this.withTags(Arrays.asList(tags));
+        }
+
         // withTag adds a single tag to the tags list
         public T withTag(String tag) {
-            return this.withTags(tag);
+            return this.withTags(Arrays.asList(tag));
         }
 
         // withIncludeMeta sets the includeMeta flag

--- a/src/main/java/ai/chalk/models/OnlineQueryParams.java
+++ b/src/main/java/ai/chalk/models/OnlineQueryParams.java
@@ -169,17 +169,11 @@ public class OnlineQueryParams {
         }
 
         // withTags takes either multiple arguments or a single list of tags and adds them to the tags list
-        public T withTags(Object... tags) {
+        public T withTags(List<String> tags) {
             if (this.tags == null) {
                 this.tags = new ArrayList<>();
             }
-            if (tags.length == 1 && tags[0] instanceof List) {
-                this.tags.addAll((List<String>) tags[0]);
-            } else {
-                for (Object tag : tags) {
-                    this.tags.add((String) tag);
-                }
-            }
+            this.tags.addAll(tags);
             return (T) this;
         }
 

--- a/src/main/java/ai/chalk/models/OnlineQueryParams.java
+++ b/src/main/java/ai/chalk/models/OnlineQueryParams.java
@@ -151,20 +151,11 @@ public class OnlineQueryParams {
             return (T) this._withOutputs(outputFqns);
         }
 
-        // withStaleness takes alternating key, value pairs and adds them to the staleness map
-        public T withStaleness(Object... staleness) {
+        public T withStaleness(Map<String, Duration> staleness) {
             if (this.staleness == null) {
                 this.staleness = new HashMap<>();
             }
-            if (staleness.length % 2 != 0) {
-                throw new IllegalArgumentException("staleness must be an even number of alternating keys and values");
-            }
-            for (int i = 0; i < staleness.length; i += 2) {
-                if (!(staleness[i] instanceof String)) {
-                    throw new IllegalArgumentException("staleness must be an even number of alternating keys and values");
-                }
-                this.staleness.put((String) staleness[i], (Duration) staleness[i + 1]);
-            }
+            this.staleness.putAll(staleness);
             return (T) this;
         }
 

--- a/src/main/java/ai/chalk/models/OnlineQueryParams.java
+++ b/src/main/java/ai/chalk/models/OnlineQueryParams.java
@@ -160,12 +160,12 @@ public class OnlineQueryParams {
             return (T) this;
         }
 
-        // withMeta adds a single key, value pair to the meta map
-        public T withMeta(String key, String value) {
+        // withMeta takes a map of meta key to meta value and adds them to the meta map
+        public T withMeta(Map<String, String> meta) {
             if (this.meta == null) {
                 this.meta = new HashMap<>();
             }
-            this.meta.put(key, value);
+            this.meta.putAll(meta);
             return (T) this;
         }
 

--- a/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
+++ b/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
@@ -70,6 +70,7 @@ public class TestOnlineQueryParams {
                 }})
                 .withMeta("user.id", "abc")
                 .withTags(Arrays.asList("user.id", "abc"))
+                .withTags("def")
                 .withIncludeMeta(true)
                 .withIncludeMetrics(true)
                 .withEnvironmentId("abc")
@@ -82,6 +83,7 @@ public class TestOnlineQueryParams {
         assert paramsSeed.getMeta().get("user.id").equals("abc");
         assert paramsSeed.getTags().get(0).equals("user.id");
         assert paramsSeed.getTags().get(1).equals("abc");
+        assert paramsSeed.getTags().get(2).equals("def");
         assert paramsSeed.isIncludeMeta();
         assert paramsSeed.isIncludeMetrics();
         assert paramsSeed.getEnvironmentId().equals("abc");
@@ -98,6 +100,7 @@ public class TestOnlineQueryParams {
                 }})
                 .withMeta("user.id", "abc")
                 .withTags(Arrays.asList("user.id", "abc"))
+                .withTags("def")
                 .withIncludeMeta(true)
                 .withIncludeMetrics(true)
                 .withEnvironmentId("abc")
@@ -114,6 +117,7 @@ public class TestOnlineQueryParams {
         assert paramsWithInputs.getMeta().get("user.id").equals("abc");
         assert paramsWithInputs.getTags().get(0).equals("user.id");
         assert paramsWithInputs.getTags().get(1).equals("abc");
+        assert paramsWithInputs.getTags().get(2).equals("def");
         assert paramsWithInputs.isIncludeMeta();
         assert paramsWithInputs.isIncludeMetrics();
         assert paramsWithInputs.getEnvironmentId().equals("abc");
@@ -129,6 +133,7 @@ public class TestOnlineQueryParams {
                 }})
                 .withMeta("user.id", "abc")
                 .withTags(Arrays.asList("user.id", "abc"))
+                .withTags("def")
                 .withIncludeMeta(true)
                 .withIncludeMetrics(true)
                 .withEnvironmentId("abc")
@@ -144,6 +149,7 @@ public class TestOnlineQueryParams {
         assert paramsWithOutputs.getMeta().get("user.id").equals("abc");
         assert paramsWithOutputs.getTags().get(0).equals("user.id");
         assert paramsWithOutputs.getTags().get(1).equals("abc");
+        assert paramsWithOutputs.getTags().get(2).equals("def");
         assert paramsWithOutputs.isIncludeMeta();
         assert paramsWithOutputs.isIncludeMetrics();
         assert paramsWithOutputs.getEnvironmentId().equals("abc");
@@ -160,6 +166,7 @@ public class TestOnlineQueryParams {
                 }})
                 .withMeta("user.id", "abc")
                 .withTags(Arrays.asList("user.id", "abc"))
+                .withTags("def")
                 .withIncludeMeta(true)
                 .withIncludeMetrics(true)
                 .withEnvironmentId("abc")
@@ -178,6 +185,7 @@ public class TestOnlineQueryParams {
         assert paramsComplete.getMeta().get("user.id").equals("abc");
         assert paramsComplete.getTags().get(0).equals("user.id");
         assert paramsComplete.getTags().get(1).equals("abc");
+        assert paramsComplete.getTags().get(2).equals("def");
         assert paramsComplete.isIncludeMeta();
         assert paramsComplete.isIncludeMetrics();
         assert paramsComplete.getEnvironmentId().equals("abc");

--- a/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
+++ b/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
@@ -65,7 +65,9 @@ public class TestOnlineQueryParams {
 
         // Test BuilderSeed with optional params
         OnlineQueryParams.BuilderSeed builderSeed = OnlineQueryParams.builder()
-                .withStaleness("user.id", Duration.ofSeconds(1000))
+                .withStaleness(new HashMap<>() {{
+                    put("user.id", Duration.ofSeconds(1000));
+                }})
                 .withMeta("user.id", "abc")
                 .withTags("user.id", "abc")
                 .withIncludeMeta(true)
@@ -91,7 +93,9 @@ public class TestOnlineQueryParams {
         // Test BuilderWithInputs with optional params
         OnlineQueryParams.BuilderWithInputs builderWithInputs = OnlineQueryParams.builder()
                 .withInputs(inputs)
-                .withStaleness("user.id", Duration.ofSeconds(1000))
+                .withStaleness(new HashMap<>() {{
+                    put("user.id", Duration.ofSeconds(1000));
+                }})
                 .withMeta("user.id", "abc")
                 .withTags("user.id", "abc")
                 .withIncludeMeta(true)
@@ -120,7 +124,9 @@ public class TestOnlineQueryParams {
         // Test BuilderWithOutputs with optional params
         OnlineQueryParams.BuilderWithOutputs builderWithOutputs = OnlineQueryParams.builder()
                 .withOutputs(outputs)
-                .withStaleness("user.id", Duration.ofSeconds(1000))
+                .withStaleness(new HashMap<>() {{
+                    put("user.id", Duration.ofSeconds(1000));
+                }})
                 .withMeta("user.id", "abc")
                 .withTags("user.id", "abc")
                 .withIncludeMeta(true)
@@ -149,7 +155,9 @@ public class TestOnlineQueryParams {
         OnlineQueryParams.BuilderComplete builderComplete = OnlineQueryParams.builder()
                 .withInputs(inputs)
                 .withOutputs(outputs)
-                .withStaleness("user.id", Duration.ofSeconds(1000))
+                .withStaleness(new HashMap<>() {{
+                    put("user.id", Duration.ofSeconds(1000));
+                }})
                 .withMeta("user.id", "abc")
                 .withTags("user.id", "abc")
                 .withIncludeMeta(true)

--- a/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
+++ b/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
@@ -68,7 +68,9 @@ public class TestOnlineQueryParams {
                 .withStaleness(new HashMap<>() {{
                     put("user.id", Duration.ofSeconds(1000));
                 }})
-                .withMeta("user.id", "abc")
+                .withMeta(new HashMap<>() {{
+                    put("user.id", "abc");
+                }})
                 .withTags(Arrays.asList("user.id", "abc"))
                 .withTags("def")
                 .withIncludeMeta(true)
@@ -98,7 +100,9 @@ public class TestOnlineQueryParams {
                 .withStaleness(new HashMap<>() {{
                     put("user.id", Duration.ofSeconds(1000));
                 }})
-                .withMeta("user.id", "abc")
+                .withMeta(new HashMap<>() {{
+                    put("user.id", "abc");
+                }})
                 .withTags(Arrays.asList("user.id", "abc"))
                 .withTags("def")
                 .withIncludeMeta(true)
@@ -131,7 +135,9 @@ public class TestOnlineQueryParams {
                 .withStaleness(new HashMap<>() {{
                     put("user.id", Duration.ofSeconds(1000));
                 }})
-                .withMeta("user.id", "abc")
+                .withMeta(new HashMap<>() {{
+                    put("user.id", "abc");
+                }})
                 .withTags(Arrays.asList("user.id", "abc"))
                 .withTags("def")
                 .withIncludeMeta(true)
@@ -164,7 +170,9 @@ public class TestOnlineQueryParams {
                 .withStaleness(new HashMap<>() {{
                     put("user.id", Duration.ofSeconds(1000));
                 }})
-                .withMeta("user.id", "abc")
+                .withMeta(new HashMap<>() {{
+                    put("user.id", "abc");
+                }})
                 .withTags(Arrays.asList("user.id", "abc"))
                 .withTags("def")
                 .withIncludeMeta(true)

--- a/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
+++ b/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
@@ -69,7 +69,7 @@ public class TestOnlineQueryParams {
                     put("user.id", Duration.ofSeconds(1000));
                 }})
                 .withMeta("user.id", "abc")
-                .withTags("user.id", "abc")
+                .withTags(Arrays.asList("user.id", "abc"))
                 .withIncludeMeta(true)
                 .withIncludeMetrics(true)
                 .withEnvironmentId("abc")
@@ -97,7 +97,7 @@ public class TestOnlineQueryParams {
                     put("user.id", Duration.ofSeconds(1000));
                 }})
                 .withMeta("user.id", "abc")
-                .withTags("user.id", "abc")
+                .withTags(Arrays.asList("user.id", "abc"))
                 .withIncludeMeta(true)
                 .withIncludeMetrics(true)
                 .withEnvironmentId("abc")
@@ -128,7 +128,7 @@ public class TestOnlineQueryParams {
                     put("user.id", Duration.ofSeconds(1000));
                 }})
                 .withMeta("user.id", "abc")
-                .withTags("user.id", "abc")
+                .withTags(Arrays.asList("user.id", "abc"))
                 .withIncludeMeta(true)
                 .withIncludeMetrics(true)
                 .withEnvironmentId("abc")
@@ -159,7 +159,7 @@ public class TestOnlineQueryParams {
                     put("user.id", Duration.ofSeconds(1000));
                 }})
                 .withMeta("user.id", "abc")
-                .withTags("user.id", "abc")
+                .withTags(Arrays.asList("user.id", "abc"))
                 .withIncludeMeta(true)
                 .withIncludeMetrics(true)
                 .withEnvironmentId("abc")


### PR DESCRIPTION
Builder methods signatures were not the most user friendly. This PR improves upon that. Specifically, we purge all instances where we took in `Object...`, and we also change methods that add to a map to take in a map. 