### PR TITLE
Set keep alive to 300

### DIFF
--- a/src/main/java/ai/chalk/internal/request/RequestHandler.java
+++ b/src/main/java/ai/chalk/internal/request/RequestHandler.java
@@ -47,6 +47,7 @@ public class RequestHandler {
             String branch
     ) {
         if (httpClient == null) {
+            System.setProperty("jdk.httpclient.keepalive.timeout", "300");
             this.httpClient = HttpClient.newHttpClient();
         } else {
             this.httpClient = httpClient;


### PR DESCRIPTION
The default of 1200 when using JDK 17 is too high, and the server closes the connection but our client tries to reuse the connection. 