### PR TITLE
Use LargeUTF8 and LargeBinary instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Java client is hosted on Maven Central.
 #### Gradle
 Add the following dependency block to your `build.gradle`. 
 ```java
-implementation 'ai.chalk:chalk-java:0.5.4'
+implementation 'ai.chalk:chalk-java:0.6.0'
 ```
 
 #### Maven
@@ -22,7 +22,7 @@ Add the following dependency block to your `pom.xml`.
     <dependency>
         <groupId>ai.chalk</groupId>
         <artifactId>chalk-java</artifactId>
-        <version>0.5.4</version>
+        <version>0.6.0</version>
     </dependency>
 </dependencies>
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'ai.chalk'
-version '0.5.4'
+version '0.6.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/ai/chalk/internal/arrow/FeatherProcessor.java
+++ b/src/main/java/ai/chalk/internal/arrow/FeatherProcessor.java
@@ -29,9 +29,9 @@ public class FeatherProcessor {
         javaToArrowType.put(Long.class, new ArrowType.Int(64, true));
         javaToArrowType.put(Float.class, new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE));
         javaToArrowType.put(Double.class, new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE));
-        javaToArrowType.put(String.class, ArrowType.Utf8.INSTANCE);
+        javaToArrowType.put(String.class, ArrowType.LargeUtf8.INSTANCE);
         javaToArrowType.put(Boolean.class, ArrowType.Bool.INSTANCE);
-        javaToArrowType.put(byte[].class, ArrowType.Binary.INSTANCE);
+        javaToArrowType.put(byte[].class, ArrowType.LargeBinary.INSTANCE);
     }
 
     public static byte[] inputsToArrowBytes(Map<String, List<?>> inputs) throws Exception {
@@ -74,9 +74,9 @@ public class FeatherProcessor {
                         vector = new Float8Vector(field.getName(), new RootAllocator(Long.MAX_VALUE));
                     }
                 }
-                case Utf8 -> vector = new VarCharVector(field.getName(), new RootAllocator(Long.MAX_VALUE));
+                case LargeUtf8 -> vector = new VarCharVector(field.getName(), new RootAllocator(Long.MAX_VALUE));
                 case Bool -> vector = new BitVector(field.getName(), new RootAllocator(Long.MAX_VALUE));
-                case Binary -> vector = new LargeVarBinaryVector(field.getName(), new RootAllocator(Long.MAX_VALUE));
+                case LargeBinary -> vector = new LargeVarBinaryVector(field.getName(), new RootAllocator(Long.MAX_VALUE));
                 default -> throw new Exception("Unsupported arrow type: " + field.getType().getTypeID());
             }
             fieldVectors.add(vector);

--- a/src/main/java/ai/chalk/internal/arrow/FeatherProcessor.java
+++ b/src/main/java/ai/chalk/internal/arrow/FeatherProcessor.java
@@ -74,7 +74,7 @@ public class FeatherProcessor {
                         vector = new Float8Vector(field.getName(), new RootAllocator(Long.MAX_VALUE));
                     }
                 }
-                case LargeUtf8 -> vector = new VarCharVector(field.getName(), new RootAllocator(Long.MAX_VALUE));
+                case LargeUtf8 -> vector = new LargeVarCharVector(field.getName(), new RootAllocator(Long.MAX_VALUE));
                 case Bool -> vector = new BitVector(field.getName(), new RootAllocator(Long.MAX_VALUE));
                 case LargeBinary -> vector = new LargeVarBinaryVector(field.getName(), new RootAllocator(Long.MAX_VALUE));
                 default -> throw new Exception("Unsupported arrow type: " + field.getType().getTypeID());
@@ -117,8 +117,8 @@ public class FeatherProcessor {
                         doubleVector.setValueCount(values.size());
                     }
                 }
-                case Utf8 -> {
-                    VarCharVector varcharVector = (VarCharVector) vector;
+                case LargeUtf8 -> {
+                    LargeVarCharVector varcharVector = (LargeVarCharVector) vector;
                     varcharVector.allocateNew(values.size());
                     for (int i = 0; i < values.size(); i++) {
                         varcharVector.set(i, ((String) values.get(i)).getBytes());
@@ -133,7 +133,7 @@ public class FeatherProcessor {
                     }
                     boolVector.setValueCount(values.size());
                 }
-                case Binary -> {
+                case LargeBinary -> {
                     LargeVarBinaryVector binaryVector = (LargeVarBinaryVector) vector;
                     binaryVector.allocateNew(values.size());
                     for (int i = 0; i < values.size(); i++) {

--- a/src/main/java/ai/chalk/internal/arrow/FeatherProcessor.java
+++ b/src/main/java/ai/chalk/internal/arrow/FeatherProcessor.java
@@ -119,7 +119,10 @@ public class FeatherProcessor {
                 }
                 case LargeUtf8 -> {
                     LargeVarCharVector varcharVector = (LargeVarCharVector) vector;
-                    varcharVector.allocateNew(values.size());
+                    long totalBytes = values.stream()
+                            .mapToLong(v -> ((String) v).getBytes().length)
+                            .sum();
+                    varcharVector.allocateNew(totalBytes, values.size());
                     for (int i = 0; i < values.size(); i++) {
                         varcharVector.set(i, ((String) values.get(i)).getBytes());
                     }
@@ -135,7 +138,10 @@ public class FeatherProcessor {
                 }
                 case LargeBinary -> {
                     LargeVarBinaryVector binaryVector = (LargeVarBinaryVector) vector;
-                    binaryVector.allocateNew(values.size());
+                    long totalBytes = values.stream()
+                            .mapToLong(v -> ((byte[]) v).length)
+                            .sum();
+                    binaryVector.allocateNew(totalBytes, values.size());
                     for (int i = 0; i < values.size(); i++) {
                         binaryVector.set(i, (byte[]) values.get(i));
                     }

--- a/src/main/java/ai/chalk/models/OnlineQueryResult.java
+++ b/src/main/java/ai/chalk/models/OnlineQueryResult.java
@@ -54,9 +54,13 @@ public class OnlineQueryResult implements AutoCloseable {
      * close releases resources associated with the result.
      */
     public void close() {
-        scalarsTable.close();
-        for (Table table : groupsTables.values()) {
-            table.close();
+        if (scalarsTable != null) {
+            scalarsTable.close();
+        }
+        if (groupsTables != null) {
+            for (Table table : groupsTables.values()) {
+                table.close();
+            }
         }
     }
 

--- a/src/test/java/ai/chalk/client/TestChalkClient.java
+++ b/src/test/java/ai/chalk/client/TestChalkClient.java
@@ -40,6 +40,7 @@ public class TestChalkClient {
                 .build();
 
         try (OnlineQueryResult result = client.onlineQuery(params)) {
+            assert result.getErrors().length == 0;
             var users = result.unmarshal(User.class);
             assert users.length == userIds.length;
             assert users[0].socure_score.getValue().equals(123.0);

--- a/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
+++ b/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
@@ -222,7 +222,14 @@ public class TestOnlineQueryParams {
     @Test
     public void testLargeUtf8AsInput() throws Exception {
         var largeString = "a".repeat(100000);
-        var params = OnlineQueryParams.builder().withInput("user.id", Arrays.asList(largeString)).withOutputs("user.today", "user.socure_score").build();
+        var params = OnlineQueryParams.builder().withInput("user.id", Arrays.asList(largeString, largeString)).withOutputs("user.today", "user.socure_score").build();
+        BytesProducer.convertOnlineQueryParamsToBytes(params);
+    }
+
+    @Test
+    public void testLargeBinaryAsInput() throws Exception {
+        var largeBinary = "a".repeat(100000).getBytes();
+        var params = OnlineQueryParams.builder().withInput("user.binary_data", Arrays.asList(largeBinary, largeBinary)).withOutputs("user.today", "user.socure_score").build();
         BytesProducer.convertOnlineQueryParamsToBytes(params);
     }
 

--- a/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
+++ b/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
@@ -219,6 +219,13 @@ public class TestOnlineQueryParams {
         BytesProducer.convertOnlineQueryParamsToBytes(paramsComplete);
     }
 
+    @Test
+    public void testLargeUtf8AsInput() throws Exception {
+        var largeString = "a".repeat(100000);
+        var params = OnlineQueryParams.builder().withInput("user.id", Arrays.asList(largeString)).withOutputs("user.today", "user.socure_score").build();
+        BytesProducer.convertOnlineQueryParamsToBytes(params);
+    }
+
 
     @Test
     public void testSerializationWithListAsInputValuesBatch() throws Exception {


### PR DESCRIPTION
This PR builds a query input arrow table with strings that default to the type LargeUTF8 and binary data that default to the type LargeBinary 