### PR TITLE
Fix error not showing when chalk yaml parsing fails 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Java client is hosted on Maven Central.
 #### Gradle
 Add the following dependency block to your `build.gradle`. 
 ```java
-implementation 'ai.chalk:chalk-java:0.6.5'
+implementation 'ai.chalk:chalk-java:0.6.6'
 ```
 
 #### Maven
@@ -22,7 +22,7 @@ Add the following dependency block to your `pom.xml`.
     <dependency>
         <groupId>ai.chalk</groupId>
         <artifactId>chalk-java</artifactId>
-        <version>0.6.5</version>
+        <version>0.6.6</version>
     </dependency>
 </dependencies>
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'ai.chalk'
-version '0.6.5'
+version '0.6.6'
 
 repositories {
     mavenCentral()
@@ -117,10 +117,10 @@ nexusPublishing {
         }
     }
 }
-
-signing {
-    def signingKey = System.getenv("SIGNING_PRIVATE_KEY") ?: project.findProperty("signingPrivateKey")
-    def signingPassword = System.getenv("SIGNING_PASSWORD") ?: project.findProperty("signingPassword")
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign publishing.publications
-}
+//
+//signing {
+//    def signingKey = System.getenv("SIGNING_PRIVATE_KEY") ?: project.findProperty("signingPrivateKey")
+//    def signingPassword = System.getenv("SIGNING_PASSWORD") ?: project.findProperty("signingPassword")
+//    useInMemoryPgpKeys(signingKey, signingPassword)
+//    sign publishing.publications
+//}

--- a/build.gradle
+++ b/build.gradle
@@ -117,10 +117,10 @@ nexusPublishing {
         }
     }
 }
-//
-//signing {
-//    def signingKey = System.getenv("SIGNING_PRIVATE_KEY") ?: project.findProperty("signingPrivateKey")
-//    def signingPassword = System.getenv("SIGNING_PASSWORD") ?: project.findProperty("signingPassword")
-//    useInMemoryPgpKeys(signingKey, signingPassword)
-//    sign publishing.publications
-//}
+
+signing {
+    def signingKey = System.getenv("SIGNING_PRIVATE_KEY") ?: project.findProperty("signingPrivateKey")
+    def signingPassword = System.getenv("SIGNING_PASSWORD") ?: project.findProperty("signingPassword")
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign publishing.publications
+}

--- a/src/main/java/ai/chalk/client/ChalkClientImpl.java
+++ b/src/main/java/ai/chalk/client/ChalkClientImpl.java
@@ -79,8 +79,8 @@ public class ChalkClientImpl implements ChalkClient {
         try {
             projectRoot = Loader.loadProjectDirectory();
             chalkYamlConfig = Loader.getChalkYamlConfig(projectRoot);
-        } catch (Exception deferredExc) {
-            chalkYamlExc = deferredExc;
+        } catch (Exception deferredException) {
+            chalkYamlExc = deferredException;
         }
 
         ResolvedConfig config = ResolvedConfig.fromBuilder(builder, chalkYamlConfig);

--- a/src/main/java/ai/chalk/client/ChalkClientImpl.java
+++ b/src/main/java/ai/chalk/client/ChalkClientImpl.java
@@ -73,11 +73,13 @@ public class ChalkClientImpl implements ChalkClient {
     private ResolvedConfig resolveConfig(BuilderImpl builder) throws ClientException {
         ProjectToken chalkYamlConfig = new ProjectToken();
         String projectRoot;
+
+        Exception chalkYamlExc = null;
         try {
             projectRoot = Loader.loadProjectDirectory();
             chalkYamlConfig = Loader.getChalkYamlConfig(projectRoot);
-        } catch (Exception ignored) {
-            // TODO: Add some logging here
+        } catch (Exception deferredException) {
+            chalkYamlExc = deferredException;
         }
 
         ResolvedConfig config = ResolvedConfig.fromBuilder(builder, chalkYamlConfig);
@@ -87,7 +89,12 @@ public class ChalkClientImpl implements ChalkClient {
                 config.apiServer().value().isEmpty() ||
                 config.environmentId().value().isEmpty()) {
             System.err.println(this.getConfigStr());
-            throw new ClientException("Chalk's config variables are not set correctly. See error log for more details.");
+            String msg = "Chalk's config variables are not set correctly. See error log for more details.";
+            if (chalkYamlExc != null) {
+                throw new ClientException(msg, chalkYamlExc);
+            } else {
+                throw new ClientException(msg);
+            }
         }
 
         return config;

--- a/src/main/java/ai/chalk/client/ChalkClientImpl.java
+++ b/src/main/java/ai/chalk/client/ChalkClientImpl.java
@@ -89,7 +89,7 @@ public class ChalkClientImpl implements ChalkClient {
                 config.apiServer().value().isEmpty() ||
                 config.environmentId().value().isEmpty()) {
             System.err.println(this.getConfigStr());
-            String msg = "Chalk's config variables are not set correctly. See error log for more details.";
+            String msg = "Chalk's config variables are not set correctly. See error log or stacktrace for more details.";
             if (chalkYamlExc != null) {
                 throw new ClientException(msg, chalkYamlExc);
             } else {

--- a/src/main/java/ai/chalk/internal/config/Loader.java
+++ b/src/main/java/ai/chalk/internal/config/Loader.java
@@ -46,7 +46,7 @@ public class Loader {
         return Paths.get(configDir, ".chalk.yml");
     }
 
-    private static ProjectToken getProjectToken(ProjectTokens config, String configPath, String projectRoot) throws Exception {
+    public static ProjectToken getProjectToken(ProjectTokens config, String configPath, String projectRoot) throws Exception {
         if (config.getTokens() == null) {
             throw new Exception(String.format("'tokens' collection does not exist or is empty in the auth config file '%s' -- please try to 'chalk login' again", configPath));
         }
@@ -69,14 +69,7 @@ public class Loader {
         return returnToken;
     }
 
-    private static ProjectTokens loadAllTokens() throws IOException {
-        Path path;
-        try {
-            path = getConfigPath();
-        } catch (Exception e) {
-            throw new IOException("Error getting auth config path");
-        }
-
+    public static ProjectTokens loadAllTokens(Path path) throws IOException {
         byte[] data;
         try {
             data = Files.readAllBytes(path);
@@ -97,7 +90,13 @@ public class Loader {
     }
 
     public static ProjectToken getChalkYamlConfig(String projectRoot) throws Exception {
-        ProjectTokens config = loadAllTokens();
-        return getProjectToken(config, getConfigPath().toString(), projectRoot);
+        Path path;
+        try {
+            path = getConfigPath();
+        } catch (Exception e) {
+            throw new IOException("Error getting auth config path");
+        }
+        ProjectTokens config = loadAllTokens(path);
+        return getProjectToken(config, path.toString(), projectRoot);
     }
 }

--- a/src/main/java/ai/chalk/internal/config/models/SourcedConfig.java
+++ b/src/main/java/ai/chalk/internal/config/models/SourcedConfig.java
@@ -26,13 +26,17 @@ public record SourcedConfig(String source, String value) {
         return new SourcedConfig(String.format("config file %s", pathStr), value);
     }
 
+    public static SourcedConfig missing() {
+        return new SourcedConfig("missing", "");
+    }
+
     public static @NonNull SourcedConfig firstNonEmpty(SourcedConfig... configs) {
         for (SourcedConfig config : configs) {
             if (config != null && config.value() != null && !config.value().isEmpty()) {
                 return config;
             }
         }
-        return new SourcedConfig("missing", "");
+        return SourcedConfig.missing();
     }
 
 

--- a/src/test/java/ai/chalk/internal/TestConfigLoader.java
+++ b/src/test/java/ai/chalk/internal/TestConfigLoader.java
@@ -1,0 +1,58 @@
+package ai.chalk.internal;
+
+import ai.chalk.internal.config.Loader;
+import ai.chalk.internal.config.models.ProjectTokens;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+
+import static ai.chalk.internal.config.Loader.getProjectToken;
+
+
+public class TestConfigLoader {
+
+    public Path writeTempYAMLFile() throws Exception {
+        String yamlContent = """
+            tokens:
+              /Users/papan/dev/my_project:
+                name: my-project Token
+                clientId: client-my-project
+                clientSecret: secret-my-project
+                validUntil: 2025-05-02T17:32:46.165000
+                apiServer: https://api.chalk.ai
+                activeEnvironment: myprojectenvid
+              default:
+                name: Default Token
+                clientId: client-default
+                clientSecret: secret-default
+                validUntil: 2024-09-11T15:07:50.812000
+                apiServer: http://api.chalk.ai
+                activeEnvironment: defaultenvid
+            """;
+        Path tempYamlFile = Files.createTempFile(".chalk", ".yml");
+        Files.writeString(tempYamlFile, yamlContent);
+        System.out.println("Temporary YAML file created at: " + tempYamlFile);
+        return tempYamlFile;
+    }
+
+    @Test
+    public void TestLoadAllTokens() throws Exception {
+        var tempFile = writeTempYAMLFile();
+        ProjectTokens config = Loader.loadAllTokens(tempFile);
+        var token = getProjectToken(config, tempFile.toString(), "/Users/papan/dev/my_project");
+        assert token.getClientId().equals("client-my-project");
+        assert token.getClientSecret().equals("secret-my-project");
+        assert token.getApiServer().equals("https://api.chalk.ai");
+        assert token.getActiveEnvironment().equals("myprojectenvid");
+        assert token.getValidUntil().equals(LocalDateTime.of(2025, 5, 2, 17, 32, 46, 165_000_000));
+
+        var defaultToken = getProjectToken(config, tempFile.toString(), "/Users/papan/dev/project_that_doesnt_exist");
+        assert defaultToken.getClientId().equals("client-default");
+        assert defaultToken.getClientSecret().equals("secret-default");
+        assert defaultToken.getActiveEnvironment().equals("defaultenvid");
+        assert defaultToken.getValidUntil().equals(LocalDateTime.of(2024, 9, 11, 15, 7, 50, 812_000_000));
+    }
+}
+


### PR DESCRIPTION
We were failing to parse a timestamp string in chalk.yaml, but errors were not shown due to multiple issues. This PR fixes those issues:

- [x] `ChalkClientImpl.getConfigStr()` was failing due to the config attributes being `null`
- [x] We just were not throwing errors when chalk yaml parsing fails. 