### PR TITLE
FeatureBase as output

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Java client is hosted on Maven Central.
 #### Gradle
 Add the following dependency block to your `build.gradle`. 
 ```java
-implementation 'ai.chalk:chalk-java:0.8.0'
+implementation 'ai.chalk:chalk-java:0.8.1'
 ```
     
 #### Maven
@@ -22,7 +22,7 @@ Add the following dependency block to your `pom.xml`.
     <dependency>
         <groupId>ai.chalk</groupId>
         <artifactId>chalk-java</artifactId>
-        <version>0.8.0</version>
+        <version>0.8.1</version>
     </dependency>
 </dependencies>
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'ai.chalk'
-version '0.8.0'
+version '0.8.1'
 
 repositories {
     mavenCentral()

--- a/src/main/java/ai/chalk/models/OnlineQueryParams.java
+++ b/src/main/java/ai/chalk/models/OnlineQueryParams.java
@@ -1,6 +1,7 @@
 package ai.chalk.models;
 
 import ai.chalk.features.Feature;
+import ai.chalk.features.FeaturesBase;
 import ai.chalk.features.StructFeaturesClass;
 import ai.chalk.features.WindowedFeaturesClass;
 import lombok.AllArgsConstructor;
@@ -174,15 +175,7 @@ public class OnlineQueryParams {
             return this._withOutputs(outputFqns);
         }
 
-        public T _withOutputs(WindowedFeaturesClass... outputs) {
-            var outputFqns = new String[outputs.length];
-            for (int i = 0; i < outputs.length; i++) {
-                outputFqns[i] = outputs[i].getFqn();
-            }
-            return this._withOutputs(outputFqns);
-        }
-
-        public T _withOutputs(StructFeaturesClass... outputs) {
+        public T _withOutputs(FeaturesBase... outputs) {
             var outputFqns = new String[outputs.length];
             for (int i = 0; i < outputs.length; i++) {
                 outputFqns[i] = outputs[i].getFqn();
@@ -328,11 +321,7 @@ public class OnlineQueryParams {
             return this._withOutputs(outputs);
         }
 
-        public BuilderComplete withOutputs(WindowedFeaturesClass... outputs) {
-            return this._withOutputs(outputs);
-        }
-
-        public BuilderComplete withOutputs(StructFeaturesClass... outputs) {
+        public BuilderComplete withOutputs(FeaturesBase... outputs) {
             return this._withOutputs(outputs);
         }
 
@@ -393,11 +382,7 @@ public class OnlineQueryParams {
             return this.newBuilderComplete()._withOutputs(outputs);
         }
 
-        public BuilderComplete withOutputs(WindowedFeaturesClass... outputs) {
-            return this.newBuilderComplete()._withOutputs(outputs);
-        }
-
-        public BuilderComplete withOutputs(StructFeaturesClass... outputs) {
+        public BuilderComplete withOutputs(FeaturesBase... outputs) {
             return this.newBuilderComplete()._withOutputs(outputs);
         }
     }
@@ -455,11 +440,7 @@ public class OnlineQueryParams {
             return this._withOutputs(outputs);
         }
 
-        public BuilderWithOutputs withOutputs(WindowedFeaturesClass... outputs) {
-            return this._withOutputs(outputs);
-        }
-
-        public BuilderWithOutputs withOutputs(StructFeaturesClass... outputs) {
+        public BuilderWithOutputs withOutputs(FeaturesBase... outputs) {
             return this._withOutputs(outputs);
         }
     }

--- a/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
+++ b/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
@@ -585,7 +585,8 @@ public class TestOnlineQueryParams {
                 .builder()
                 .withInput(InitFeaturesTestFeatures.user.id, "1", "2", "3")
                 .withOutputs(InitFeaturesTestFeatures.user.mean_attendance_count)        // WindowedFeaturesClass
-                .withOutputs(InitFeaturesTestFeatures.user.burrys_membership.branch)    // StructFeaturesClass
+                .withOutputs(InitFeaturesTestFeatures.user.burrys_membership.branch)     // StructFeaturesClass
+                .withOutputs(InitFeaturesTestFeatures.user.burrys_membership)            // FeaturesClass
                 .build();
         assert Arrays.equals(p.getOutputs().toArray(), new String[]{"test_user.mean_attendance_count", "test_user.burrys_membership.branch"});
         // Test serialization is OK.
@@ -621,5 +622,9 @@ public class TestOnlineQueryParams {
         assert InitFeaturesTestFeatures.user.mean_attendance_count.getFqn().equals("test_user.mean_attendance_count");
         assert InitFeaturesTestFeatures.user.mean_attendance_count.bucket_all.getFqn().equals("test_user.mean_attendance_count__all__");
         assert InitFeaturesTestFeatures.user.mean_attendance_count.bucket_1w.getFqn().equals("test_user.mean_attendance_count__604800__");
+
+        // Normal feature classes
+        assert InitFeaturesTestFeatures.user.getFqn().equals("test_user");
+        assert InitFeaturesTestFeatures.user.burrys_membership.getFqn().equals("test_user.burrys_membership");
     }
 }

--- a/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
+++ b/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
@@ -588,7 +588,11 @@ public class TestOnlineQueryParams {
                 .withOutputs(InitFeaturesTestFeatures.user.burrys_membership.branch)     // StructFeaturesClass
                 .withOutputs(InitFeaturesTestFeatures.user.burrys_membership)            // FeaturesClass
                 .build();
-        assert Arrays.equals(p.getOutputs().toArray(), new String[]{"test_user.mean_attendance_count", "test_user.burrys_membership.branch"});
+        assert Arrays.equals(p.getOutputs().toArray(), new String[]{
+                "test_user.mean_attendance_count",
+                "test_user.burrys_membership.branch",
+                "test_user.burrys_membership",
+        });
         // Test serialization is OK.
         BytesProducer.convertOnlineQueryParamsToBytes(p);
     }


### PR DESCRIPTION
This PR introduces support for using FeaturesBase as an argument to `withOutputs`