### PR TITLE
GRPC Online Query

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Java client is hosted on Maven Central.
 #### Gradle
 Add the following dependency block to your `build.gradle`. 
 ```java
-implementation 'ai.chalk:chalk-java:0.8.1'
+implementation 'ai.chalk:chalk-java:0.9.0'
 ```
     
 #### Maven
@@ -22,7 +22,7 @@ Add the following dependency block to your `pom.xml`.
     <dependency>
         <groupId>ai.chalk</groupId>
         <artifactId>chalk-java</artifactId>
-        <version>0.8.1</version>
+        <version>0.9.0</version>
     </dependency>
 </dependencies>
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'ai.chalk'
-version '0.8.3'
+version '0.9.0'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'ai.chalk'
-version '0.8.1'
+version '0.8.3'
 
 repositories {
     mavenCentral()
@@ -21,6 +21,7 @@ dependencies {
     api 'io.grpc:grpc-core:1.64.0'
     api 'io.grpc:grpc-protobuf:1.64.0'
     api 'io.grpc:grpc-stub:1.64.0'
+    api 'io.grpc:grpc-netty-shaded:1.64.0'
     api 'org.apache.arrow:arrow-compression:13.0.0'
     api 'org.apache.arrow:arrow-memory-netty:13.0.0'
     api 'org.apache.arrow:arrow-vector:13.0.0'
@@ -119,9 +120,9 @@ nexusPublishing {
     }
 }
 
-signing {
-    def signingKey = System.getenv("SIGNING_PRIVATE_KEY") ?: project.findProperty("signingPrivateKey")
-    def signingPassword = System.getenv("SIGNING_PASSWORD") ?: project.findProperty("signingPassword")
-    useInMemoryPgpKeys(signingKey, signingPassword)
-    sign publishing.publications
-}
+//signing {
+//    def signingKey = System.getenv("SIGNING_PRIVATE_KEY") ?: project.findProperty("signingPrivateKey")
+//    def signingPassword = System.getenv("SIGNING_PASSWORD") ?: project.findProperty("signingPassword")
+//    useInMemoryPgpKeys(signingKey, signingPassword)
+//    sign publishing.publications
+//}

--- a/build.gradle
+++ b/build.gradle
@@ -120,9 +120,9 @@ nexusPublishing {
     }
 }
 
-//signing {
-//    def signingKey = System.getenv("SIGNING_PRIVATE_KEY") ?: project.findProperty("signingPrivateKey")
-//    def signingPassword = System.getenv("SIGNING_PASSWORD") ?: project.findProperty("signingPassword")
-//    useInMemoryPgpKeys(signingKey, signingPassword)
-//    sign publishing.publications
-//}
+signing {
+    def signingKey = System.getenv("SIGNING_PRIVATE_KEY") ?: project.findProperty("signingPrivateKey")
+    def signingPassword = System.getenv("SIGNING_PASSWORD") ?: project.findProperty("signingPassword")
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign publishing.publications
+}

--- a/src/main/java/ai/chalk/client/AuthenticatedHeaderClientInterceptor.java
+++ b/src/main/java/ai/chalk/client/AuthenticatedHeaderClientInterceptor.java
@@ -43,11 +43,7 @@ public class AuthenticatedHeaderClientInterceptor implements ClientInterceptor {
                     headers.put(entry.getKey(), entry.getValue());
                 }
                 headers.put(GrpcHeaders.AUTHORIZATION_KEY, "Bearer " + token.getAccessToken());
-                MetadataUtils.newAttachHeadersInterceptor(headers).interceptCall(
-                        method,
-                        callOptions,
-                        next
-                );
+                super.start(responseListener, headers);
             }
         };
     }

--- a/src/main/java/ai/chalk/client/AuthenticatedHeaderClientInterceptor.java
+++ b/src/main/java/ai/chalk/client/AuthenticatedHeaderClientInterceptor.java
@@ -43,6 +43,7 @@ public class AuthenticatedHeaderClientInterceptor implements ClientInterceptor {
                     headers.put(entry.getKey(), entry.getValue());
                 }
                 headers.put(GrpcHeaders.AUTHORIZATION_KEY, "Bearer " + token.getAccessToken());
+                headers.put(GrpcHeaders.CONTENT_TYPE, "application/grpc");
                 super.start(responseListener, headers);
             }
         };

--- a/src/main/java/ai/chalk/client/AuthenticatedHeaderClientInterceptor.java
+++ b/src/main/java/ai/chalk/client/AuthenticatedHeaderClientInterceptor.java
@@ -25,6 +25,9 @@ public class AuthenticatedHeaderClientInterceptor implements ClientInterceptor {
         for (Map.Entry<String, String> entry : additionalHeaders.entrySet()) {
             this.allHeaders.put(Metadata.Key.of(entry.getKey(), Metadata.ASCII_STRING_MARSHALLER), entry.getValue());
         }
+        if (serverType.equals(ServerType.ENGINE)) {
+            this.allHeaders.put(GrpcHeaders.DEPLOYMENT_TYPE, "engine-grpc");
+        }
     }
 
     private final Map<Metadata.Key<String>, String> allHeaders;

--- a/src/main/java/ai/chalk/client/AuthenticatedHeaderClientInterceptor.java
+++ b/src/main/java/ai/chalk/client/AuthenticatedHeaderClientInterceptor.java
@@ -43,7 +43,6 @@ public class AuthenticatedHeaderClientInterceptor implements ClientInterceptor {
                     headers.put(entry.getKey(), entry.getValue());
                 }
                 headers.put(GrpcHeaders.AUTHORIZATION_KEY, "Bearer " + token.getAccessToken());
-                headers.put(GrpcHeaders.CONTENT_TYPE, "application/grpc");
                 super.start(responseListener, headers);
             }
         };

--- a/src/main/java/ai/chalk/client/BuilderImpl.java
+++ b/src/main/java/ai/chalk/client/BuilderImpl.java
@@ -20,6 +20,7 @@ public class BuilderImpl implements ChalkClient.Builder {
     private String branch;
     @Nullable
     private HttpClient httpClient;
+    private boolean useGrpc;
 
     public BuilderImpl() {
         this.clientId = null;
@@ -60,7 +61,15 @@ public class BuilderImpl implements ChalkClient.Builder {
         return this;
     }
 
+    public BuilderImpl withGrpc() {
+        this.useGrpc = true;
+        return this;
+    }
+
     public ChalkClient build() throws ChalkException {
+        if (useGrpc) {
+            return new GRPCClient(this);
+        }
         return new ChalkClientImpl(this);
     }
 }

--- a/src/main/java/ai/chalk/client/ChalkClient.java
+++ b/src/main/java/ai/chalk/client/ChalkClient.java
@@ -50,6 +50,18 @@ public interface ChalkClient {
     }
 
     /**
+     * <p> Creates a new ChalkClient instance that uses gRPC for communication.
+     * The gRPC ChalkClient instance is configured with config variables
+     * sourced the same way as the default ChalkClient instance.
+     *
+     * @return a new ChalkClient instance that uses gRPC
+     * @throws ChalkException
+     */
+    static ChalkClient createGrpc() throws ChalkException {
+        return builder().withGrpc().build();
+    }
+
+    /**
      * OnlineQuery computes features values using online resolvers.
      * <p> See {@link OnlineQueryParams} for more details on the parameters.
      *
@@ -116,6 +128,8 @@ public interface ChalkClient {
          * custom timeouts, etc.
          */
         public Builder withHttpClient(HttpClient httpClient);
+
+        public Builder withGrpc();
 
         public String getClientId();
 

--- a/src/main/java/ai/chalk/client/ChalkClientImpl.java
+++ b/src/main/java/ai/chalk/client/ChalkClientImpl.java
@@ -23,6 +23,8 @@ public class ChalkClientImpl implements ChalkClient {
     private final SourcedConfig clientSecret;
     private final RequestHandler handler;
 
+    private static final System.Logger logger = System.getLogger(ChalkClientImpl.class.getName());
+
     public ChalkClient ChalkClient() throws ChalkException {
         return ChalkClient.builder().build();
     }
@@ -127,6 +129,6 @@ public class ChalkClientImpl implements ChalkClient {
     }
 
     public void printConfig() {
-        System.out.println(this.getConfigStr());
+        logger.log(System.Logger.Level.INFO, this.getConfigStr());
     }
 }

--- a/src/main/java/ai/chalk/client/GRPCClient.java
+++ b/src/main/java/ai/chalk/client/GRPCClient.java
@@ -113,7 +113,7 @@ public class GRPCClient implements ChalkClient {
             throw new ClientException("Error getting engine URI for environment %s".formatted(environmentId), e);
         }
         Channel authenticatedEngineChannel = Grpc.newChannelBuilder(engineHost, channelCreds)
-            .maxInboundMessageSize(1024 * 1024 * 100)
+            .maxInboundMessageSize(1024 * 1024 * 500)
             .intercept(
                 new AuthenticatedHeaderClientInterceptor(
                         ServerType.ENGINE,
@@ -149,9 +149,9 @@ public class GRPCClient implements ChalkClient {
             for (var n : params.getNow()) {
                 now.add(
                     Timestamp.newBuilder()
-                    .setSeconds(n.toEpochSecond())
-                    .setNanos(n.getNano())
-                    .build()
+                        .setSeconds(n.toEpochSecond())
+                        .setNanos(n.getNano())
+                        .build()
                 );
             }
         }

--- a/src/main/java/ai/chalk/client/GRPCClient.java
+++ b/src/main/java/ai/chalk/client/GRPCClient.java
@@ -10,6 +10,7 @@ import ai.chalk.internal.config.models.ProjectToken;
 import ai.chalk.models.OnlineQueryParamsComplete;
 import ai.chalk.models.OnlineQueryResult;
 import ai.chalk.protos.chalk.common.v1.*;
+import ai.chalk.protos.chalk.engine.v1.PingRequest;
 import ai.chalk.protos.chalk.engine.v1.QueryServiceGrpc;
 import ai.chalk.protos.chalk.server.v1.AuthServiceGrpc;
 import ai.chalk.protos.chalk.server.v1.GetTokenResponse;
@@ -88,17 +89,17 @@ public class GRPCClient {
             environmentId = environmentIds.get(0);
         }
 
-        Channel authenticatedServerChannel = Grpc.newChannelBuilder(
-                grpcHost,
-                channelCreds
-        ).maxInboundMessageSize(1024 * 1024 * 100).intercept(
+        Channel authenticatedServerChannel = Grpc.newChannelBuilder(grpcHost, channelCreds)
+            .maxInboundMessageSize(1024 * 1024 * 100)
+            .intercept(
                 new AuthenticatedHeaderClientInterceptor(
                         ServerType.SERVER,
                         Map.of(),
                         tokenRefresher,
                         environmentId
                 )
-        ).build();
+            )
+            .build();
 
         this.teamStub = TeamServiceGrpc.newBlockingStub(authenticatedServerChannel);
 
@@ -117,17 +118,17 @@ public class GRPCClient {
             }
         } catch (URISyntaxException ignored) {}
 
-        Channel authenticatedEngineChannel = Grpc.newChannelBuilder(
-                engineHost,
-                channelCreds
-        ).maxInboundMessageSize(1024 * 1024 * 100).intercept(
+        Channel authenticatedEngineChannel = Grpc.newChannelBuilder(engineHost, channelCreds)
+            .maxInboundMessageSize(1024 * 1024 * 100)
+            .intercept(
                 new AuthenticatedHeaderClientInterceptor(
                         ServerType.ENGINE,
                         Map.of(),
                         tokenRefresher,
                         environmentId
                 )
-        ).build();
+            )
+            .build();
 
         this.queryStub = QueryServiceGrpc.newBlockingStub(authenticatedEngineChannel);
     }

--- a/src/main/java/ai/chalk/client/GRPCClient.java
+++ b/src/main/java/ai/chalk/client/GRPCClient.java
@@ -30,6 +30,8 @@ public class GRPCClient implements ChalkClient {
     private final TeamServiceGrpc.TeamServiceBlockingStub teamStub;
     private final QueryServiceGrpc.QueryServiceBlockingStub queryStub;
 
+    private static final System.Logger logger = System.getLogger(GRPCClient.class.getName());
+
     public GRPCClient() throws ChalkException {
         this(new BuilderImpl());
     }
@@ -128,7 +130,7 @@ public class GRPCClient implements ChalkClient {
 
     @Override
     public void printConfig() {
-        System.err.println("Config printing for GRPC client not yet implemented");
+        logger.log(System.Logger.Level.ERROR, "Config printing for GRPC client not yet implemented");
     }
 
     public OnlineQueryResult onlineQuery(OnlineQueryParamsComplete params) throws ChalkException {

--- a/src/main/java/ai/chalk/client/GRPCClient.java
+++ b/src/main/java/ai/chalk/client/GRPCClient.java
@@ -163,13 +163,26 @@ public class GRPCClient {
         if (params.getQueryName() != null) {
             context.setQueryName(params.getQueryName());
         }
-        // TODO: Add queryNameVersion
-        // TODO: Add required resolver tags
+        if (params.getQueryNameVersion() != null) {
+            context.setQueryNameVersion(params.getQueryNameVersion());
+        }
+        if (params.getTags() != null) {
+            context.addAllTags(params.getTags());
+        }
+        if (params.getRequiredResolverTags() != null) {
+            context.addAllRequiredResolverTags(params.getRequiredResolverTags());
+        }
 
-        var options = OnlineQueryResponseOptions.newBuilder();
-        // TODO: Add includeMeta
-        // TODO: Add explain
-        // TODO: Add feature encoding options
+        var options = OnlineQueryResponseOptions.newBuilder()
+                .setIncludeMeta(params.isIncludeMeta())
+                .setEncodingOptions(
+                    FeatureEncodingOptions.newBuilder()
+                        .setEncodeStructsAsObjects(true)
+                        .build()
+                );
+        if (params.isExplain()) {
+            options.setExplain(ExplainOptions.newBuilder().build());
+        }
         if (params.getMeta() != null) {
             options.putAllMetadata(params.getMeta());
         }

--- a/src/main/java/ai/chalk/client/GRPCClient.java
+++ b/src/main/java/ai/chalk/client/GRPCClient.java
@@ -30,6 +30,10 @@ public class GRPCClient implements ChalkClient {
     private final TeamServiceGrpc.TeamServiceBlockingStub teamStub;
     private final QueryServiceGrpc.QueryServiceBlockingStub queryStub;
 
+    public GRPCClient() throws ChalkException {
+        this(new BuilderImpl());
+    }
+
     public GRPCClient(BuilderImpl builder) throws ChalkException {
         ProjectToken chalkYamlConfig = new ProjectToken();
         String projectRoot;

--- a/src/main/java/ai/chalk/client/GRPCClient.java
+++ b/src/main/java/ai/chalk/client/GRPCClient.java
@@ -183,7 +183,7 @@ public class GRPCClient implements ChalkClient {
         }
 
         var options = OnlineQueryResponseOptions.newBuilder()
-                .setIncludeMeta(params.isIncludeMeta())
+                .setIncludeMeta(params.isIncludeMeta() || params.isExplain())
                 .setEncodingOptions(
                     FeatureEncodingOptions.newBuilder()
                         .setEncodeStructsAsObjects(true)

--- a/src/main/java/ai/chalk/client/GRPCClient.java
+++ b/src/main/java/ai/chalk/client/GRPCClient.java
@@ -25,7 +25,7 @@ import java.util.Map;
 
 import static ai.chalk.internal.arrow.FeatherProcessor.inputsToArrowBytes;
 
-public class GRPCClient {
+public class GRPCClient implements ChalkClient {
     private final AuthServiceGrpc.AuthServiceBlockingStub authStub;
     private final TeamServiceGrpc.TeamServiceBlockingStub teamStub;
     private final QueryServiceGrpc.QueryServiceBlockingStub queryStub;
@@ -120,6 +120,11 @@ public class GRPCClient {
             )
             .build();
         this.queryStub = QueryServiceGrpc.newBlockingStub(authenticatedEngineChannel);
+    }
+
+    @Override
+    public void printConfig() {
+        System.err.println("Config printing for GRPC client not yet implemented");
     }
 
     public OnlineQueryResult onlineQuery(OnlineQueryParamsComplete params) throws ChalkException {

--- a/src/main/java/ai/chalk/client/GRPCClient.java
+++ b/src/main/java/ai/chalk/client/GRPCClient.java
@@ -4,13 +4,11 @@ import ai.chalk.exceptions.ChalkException;
 import ai.chalk.exceptions.ClientException;
 import ai.chalk.exceptions.ServerError;
 import ai.chalk.internal.arrow.FeatherProcessor;
-import ai.chalk.internal.bytes.BytesProducer;
 import ai.chalk.internal.config.Loader;
 import ai.chalk.internal.config.models.ProjectToken;
 import ai.chalk.models.OnlineQueryParamsComplete;
 import ai.chalk.models.OnlineQueryResult;
 import ai.chalk.protos.chalk.common.v1.*;
-import ai.chalk.protos.chalk.engine.v1.PingRequest;
 import ai.chalk.protos.chalk.engine.v1.QueryServiceGrpc;
 import ai.chalk.protos.chalk.server.v1.AuthServiceGrpc;
 import ai.chalk.protos.chalk.server.v1.GetTokenResponse;
@@ -20,8 +18,6 @@ import com.google.protobuf.Timestamp;
 import io.grpc.*;
 import org.apache.arrow.vector.table.Table;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -116,10 +112,10 @@ public class GRPCClient {
             .maxInboundMessageSize(1024 * 1024 * 100)
             .intercept(
                 new AuthenticatedHeaderClientInterceptor(
-                    ServerType.ENGINE,
-                    Map.of(),
-                    tokenRefresher,
-                    environmentId
+                        ServerType.ENGINE,
+                        Map.of(),
+                        tokenRefresher,
+                        environmentId
                 )
             )
             .build();
@@ -179,13 +175,13 @@ public class GRPCClient {
         }
 
         var request = OnlineQueryBulkRequest.newBuilder()
-                .setInputsFeather(ByteString.copyFrom(bodyBytes))
-                .addAllOutputs(outputs)
-                .addAllNow(now)
-                .setBodyType(FeatherBodyType.FEATHER_BODY_TYPE_TABLE)
-                .setContext(context)
-                .setResponseOptions(options)
-                .build();
+            .setInputsFeather(ByteString.copyFrom(bodyBytes))
+            .addAllOutputs(outputs)
+            .addAllNow(now)
+            .setBodyType(FeatherBodyType.FEATHER_BODY_TYPE_TABLE)
+            .setContext(context)
+            .setResponseOptions(options)
+            .build();
         OnlineQueryBulkResponse response = this.queryStub.onlineQueryBulk(request);
 
         Table scalars = null;

--- a/src/main/java/ai/chalk/client/GrpcHeaders.java
+++ b/src/main/java/ai/chalk/client/GrpcHeaders.java
@@ -15,4 +15,8 @@ public class GrpcHeaders {
     static final Metadata.Key<String> AUTHORIZATION_KEY = Metadata.Key.of(
             "Authorization", Metadata.ASCII_STRING_MARSHALLER
     );
+
+    static final Metadata.Key<String> DEPLOYMENT_TYPE = Metadata.Key.of(
+            "x-chalk-deployment-type", Metadata.ASCII_STRING_MARSHALLER
+    );
 }

--- a/src/main/java/ai/chalk/client/GrpcHeaders.java
+++ b/src/main/java/ai/chalk/client/GrpcHeaders.java
@@ -15,4 +15,8 @@ public class GrpcHeaders {
     static final Metadata.Key<String> AUTHORIZATION_KEY = Metadata.Key.of(
             "Authorization", Metadata.ASCII_STRING_MARSHALLER
     );
+
+    static final Metadata.Key<String> CONTENT_TYPE = Metadata.Key.of(
+            "content-type", Metadata.ASCII_STRING_MARSHALLER
+    );
 }

--- a/src/main/java/ai/chalk/client/GrpcHeaders.java
+++ b/src/main/java/ai/chalk/client/GrpcHeaders.java
@@ -15,8 +15,4 @@ public class GrpcHeaders {
     static final Metadata.Key<String> AUTHORIZATION_KEY = Metadata.Key.of(
             "Authorization", Metadata.ASCII_STRING_MARSHALLER
     );
-
-    static final Metadata.Key<String> CONTENT_TYPE = Metadata.Key.of(
-            "content-type", Metadata.ASCII_STRING_MARSHALLER
-    );
 }

--- a/src/main/java/ai/chalk/client/GrpcSerializer.java
+++ b/src/main/java/ai/chalk/client/GrpcSerializer.java
@@ -1,0 +1,78 @@
+package ai.chalk.client;
+
+import ai.chalk.models.ResolverException;
+import ai.chalk.protos.chalk.common.v1.ErrorCode;
+import ai.chalk.protos.chalk.common.v1.ErrorCodeCategory;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+public class GrpcSerializer {
+    private static final Map<ErrorCode, ai.chalk.models.ErrorCode> errorCodeMap = Map.ofEntries(
+            Map.entry(ErrorCode.ERROR_CODE_INTERNAL_SERVER_ERROR_UNSPECIFIED, ai.chalk.models.ErrorCode.INTERNAL_SERVER_ERROR),
+            Map.entry(ErrorCode.ERROR_CODE_PARSE_FAILED, ai.chalk.models.ErrorCode.PARSE_FAILED),
+            Map.entry(ErrorCode.ERROR_CODE_RESOLVER_NOT_FOUND, ai.chalk.models.ErrorCode.RESOLVER_NOT_FOUND),
+            Map.entry(ErrorCode.ERROR_CODE_INVALID_QUERY, ai.chalk.models.ErrorCode.INVALID_QUERY),
+            Map.entry(ErrorCode.ERROR_CODE_VALIDATION_FAILED, ai.chalk.models.ErrorCode.VALIDATION_FAILED),
+            Map.entry(ErrorCode.ERROR_CODE_RESOLVER_FAILED, ai.chalk.models.ErrorCode.RESOLVER_FAILED),
+            Map.entry(ErrorCode.ERROR_CODE_RESOLVER_TIMED_OUT, ai.chalk.models.ErrorCode.RESOLVER_TIMED_OUT),
+            Map.entry(ErrorCode.ERROR_CODE_UPSTREAM_FAILED, ai.chalk.models.ErrorCode.UPSTREAM_FAILED),
+            Map.entry(ErrorCode.ERROR_CODE_UNAUTHENTICATED, ai.chalk.models.ErrorCode.UNAUTHENTICATED),
+            Map.entry(ErrorCode.ERROR_CODE_UNAUTHORIZED, ai.chalk.models.ErrorCode.UNAUTHORIZED),
+            Map.entry(ErrorCode.ERROR_CODE_CANCELLED, ai.chalk.models.ErrorCode.CANCELLED),
+            Map.entry(ErrorCode.ERROR_CODE_DEADLINE_EXCEEDED, ai.chalk.models.ErrorCode.DEADLINE_EXCEEDED)
+    );
+
+    private static final Map<ErrorCodeCategory, ai.chalk.models.ErrorCodeCategory> errorCategoryMap = Map.ofEntries(
+            Map.entry(ErrorCodeCategory.ERROR_CODE_CATEGORY_NETWORK_UNSPECIFIED, ai.chalk.models.ErrorCodeCategory.NETWORK),
+            Map.entry(ErrorCodeCategory.ERROR_CODE_CATEGORY_REQUEST, ai.chalk.models.ErrorCodeCategory.REQUEST),
+            Map.entry(ErrorCodeCategory.ERROR_CODE_CATEGORY_FIELD, ai.chalk.models.ErrorCodeCategory.FIELD)
+    );
+
+    public static ai.chalk.models.ResolverException toException(ai.chalk.protos.chalk.common.v1.ChalkException e) {
+        return new ai.chalk.models.ResolverException(
+                e.getKind(),
+                e.getMessage(),
+                e.getStacktrace(),
+                e.getInternalStacktrace()
+        );
+    }
+
+    public static ai.chalk.exceptions.ServerError toServerError(ai.chalk.protos.chalk.common.v1.ChalkError e) {
+        ResolverException exception = null;
+        if (e.hasException()) {
+            exception = toException(e.getException());
+        }
+
+        return new ai.chalk.exceptions.ServerError(
+                errorCodeMap.get(e.getCode()),
+                errorCategoryMap.get(e.getCategory()),
+                e.getMessage(),
+                exception,
+                e.getFeature(),
+                e.getResolver()
+        );
+    }
+
+    public static ai.chalk.models.QueryMeta toQueryMeta(ai.chalk.protos.chalk.common.v1.OnlineQueryMetadata meta) {
+        ZonedDateTime queryTimestamp = null;
+        if (meta.hasQueryTimestamp()) {
+            var ts = meta.getQueryTimestamp();
+            queryTimestamp = ZonedDateTime.ofInstant(
+                Instant.ofEpochSecond(ts.getSeconds(), ts.getNanos()),
+                ZoneOffset.UTC
+            );
+        }
+        return new ai.chalk.models.QueryMeta(
+            meta.getExecutionDuration().getSeconds() + (meta.getExecutionDuration().getNanos() / 1e9),
+            meta.getDeploymentId(),
+            meta.getEnvironmentId(),
+            meta.getEnvironmentName(),
+            meta.getQueryId(),
+            queryTimestamp,
+            meta.getQueryHash()
+        );
+    }
+}

--- a/src/main/java/ai/chalk/client/UnauthenticatedHeaderClientInterceptor.java
+++ b/src/main/java/ai/chalk/client/UnauthenticatedHeaderClientInterceptor.java
@@ -35,13 +35,7 @@ public class UnauthenticatedHeaderClientInterceptor implements ClientInterceptor
                 for (Map.Entry<Metadata.Key<String>, String> entry : allHeaders.entrySet()) {
                     headers.put(entry.getKey(), entry.getValue());
                 }
-
-                MetadataUtils.newAttachHeadersInterceptor(headers).interceptCall(
-                        method,
-                        callOptions,
-                        next
-                );
-
+                super.start(responseListener, headers);
             }
         };
     }

--- a/src/main/java/ai/chalk/exceptions/ServerError.java
+++ b/src/main/java/ai/chalk/exceptions/ServerError.java
@@ -11,6 +11,7 @@ import lombok.*;
  */
 @Data
 @NoArgsConstructor
+@AllArgsConstructor
 public class ServerError {
 
     /**

--- a/src/main/java/ai/chalk/internal/Constants.java
+++ b/src/main/java/ai/chalk/internal/Constants.java
@@ -2,4 +2,6 @@ package ai.chalk.internal;
 
 public class Constants {
     public static String tsFeatureFqn = "__ts__";
+    public static String indexFqn = "__index__";
+    public static String metadataPrefix = "__chalk__.__metadata__.";
 }

--- a/src/main/java/ai/chalk/models/OnlineQueryParams.java
+++ b/src/main/java/ai/chalk/models/OnlineQueryParams.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.ZonedDateTime;
 import java.util.*;
 import java.time.Duration;
 
@@ -109,6 +110,12 @@ public class OnlineQueryParams {
      */
     private String branch;
 
+    /**
+     * The time at which to evaluate the query. If not specified, the current time will be used.
+     * The length of this list must be the same as the length of the values in `inputs`.
+     */
+     private List<ZonedDateTime> now;
+
 
     @AllArgsConstructor
     @NoArgsConstructor
@@ -126,6 +133,7 @@ public class OnlineQueryParams {
         protected String queryName;
         protected String correlationId;
         protected String branch;
+        protected List<ZonedDateTime> now;
 
         protected T _withInput(String fqn, List<?> values) {
             if (this.inputs == null) {
@@ -220,6 +228,16 @@ public class OnlineQueryParams {
             return this.withTags(Arrays.asList(tag));
         }
 
+
+        // withNow takes a list of ZonedDateTimes and adds them to the now list
+        public T withNow(List<ZonedDateTime> now) {
+            if (this.now == null) {
+                this.now = new ArrayList<>();
+            }
+            this.now.addAll(now);
+            return (T) this;
+        }
+
         // withIncludeMeta sets the includeMeta flag
         public T withIncludeMeta(boolean includeMeta) {
             this.includeMeta = includeMeta;
@@ -269,7 +287,7 @@ public class OnlineQueryParams {
         }
 
         public OnlineQueryParams build() {
-            return new OnlineQueryParams(inputs, outputs, staleness, meta, tags, includeMeta, storePlanStages, explain, environmentId, previewDeploymentId, queryName, correlationId, branch);
+            return new OnlineQueryParams(inputs, outputs, staleness, meta, tags, includeMeta, storePlanStages, explain, environmentId, previewDeploymentId, queryName, correlationId, branch, now);
         }
     }
 
@@ -287,9 +305,25 @@ public class OnlineQueryParams {
             String previewDeploymentId,
             String queryName,
             String correlationId,
-            String branch
+            String branch,
+            List<ZonedDateTime> now
         ) {
-            super(inputs, outputs, staleness, meta, tags, includeMeta, storePlanStages, explain, environmentId, previewDeploymentId, queryName, correlationId, branch);
+            super(
+                inputs,
+                outputs,
+                staleness,
+                meta,
+                tags,
+                includeMeta,
+                storePlanStages,
+                explain,
+                environmentId,
+                previewDeploymentId,
+                queryName,
+                correlationId,
+                branch,
+                now
+            );
         }
 
         public BuilderComplete withInput(String fqn, List<?> values) {
@@ -326,7 +360,22 @@ public class OnlineQueryParams {
         }
 
         public OnlineQueryParamsComplete build() {
-            return new OnlineQueryParamsComplete(inputs, outputs, staleness, meta, tags, includeMeta, storePlanStages, explain, environmentId, previewDeploymentId, queryName, correlationId, branch);
+            return new OnlineQueryParamsComplete(
+                inputs,
+                outputs,
+                staleness,
+                meta,
+                tags,
+                includeMeta,
+                storePlanStages,
+                explain,
+                environmentId,
+                previewDeploymentId,
+                queryName,
+                correlationId,
+                branch,
+                now
+            );
         }
     }
 
@@ -344,13 +393,44 @@ public class OnlineQueryParams {
             String previewDeploymentId,
             String queryName,
             String correlationId,
-            String branch
+            String branch,
+            List<ZonedDateTime> now
         ) {
-            super(inputs, outputs, staleness, meta, tags, includeMeta, storePlanStages, explain, environmentId, previewDeploymentId, queryName, correlationId, branch);
+            super(
+                inputs,
+                outputs,
+                staleness,
+                meta,
+                tags,
+                includeMeta,
+                storePlanStages,
+                explain,
+                environmentId,
+                previewDeploymentId,
+                queryName,
+                correlationId,
+                branch,
+                now
+            );
         }
 
         private BuilderComplete newBuilderComplete() {
-            return new BuilderComplete(inputs, outputs, staleness, meta, tags, includeMeta, storePlanStages, explain, environmentId, previewDeploymentId, queryName, correlationId, branch);
+            return new BuilderComplete(
+                inputs,
+                outputs,
+                staleness,
+                meta,
+                tags,
+                includeMeta,
+                storePlanStages,
+                explain,
+                environmentId,
+                previewDeploymentId,
+                queryName,
+                correlationId,
+                branch,
+                now
+                );
         }
 
         public BuilderWithInputs withInput(String fqn, List<?> values) {
@@ -401,13 +481,45 @@ public class OnlineQueryParams {
                 String previewDeploymentId,
                 String queryName,
                 String correlationId,
-                String branch
+                String branch,
+                List<ZonedDateTime> now
         ) {
-            super(inputs, outputs, staleness, meta, tags, includeMeta, storePlanStages, explain, environmentId, previewDeploymentId, queryName, correlationId, branch);
+            super(
+                inputs,
+                outputs,
+                staleness,
+                meta,
+                tags,
+                includeMeta,
+                storePlanStages,
+                explain,
+                environmentId,
+                previewDeploymentId,
+                queryName,
+                correlationId,
+                branch,
+                now
+            );
         }
 
+
         public BuilderComplete newBuilderComplete() {
-            return new BuilderComplete(inputs, outputs, staleness, meta, tags, includeMeta, storePlanStages, explain, environmentId, previewDeploymentId, queryName, correlationId, branch);
+            return new BuilderComplete(
+                inputs,
+                outputs,
+                staleness,
+                meta,
+                tags,
+                includeMeta,
+                storePlanStages,
+                explain,
+                environmentId,
+                previewDeploymentId,
+                queryName,
+                correlationId,
+                branch,
+                now
+            );
         }
 
         public BuilderComplete withInput(String fqn, List<?> values) {
@@ -460,17 +572,63 @@ public class OnlineQueryParams {
                 String previewDeploymentId,
                 String queryName,
                 String correlationId,
-                String branch
+                String branch,
+                List<ZonedDateTime> now
         ) {
-            super(inputs, outputs, staleness, meta, tags, includeMeta, storePlanStages, explain, environmentId, previewDeploymentId, queryName, correlationId, branch);
+            super(
+                inputs,
+                outputs,
+                staleness,
+                meta,
+                tags,
+                includeMeta,
+                storePlanStages,
+                explain,
+                environmentId,
+                previewDeploymentId,
+                queryName,
+                correlationId,
+                branch,
+                now
+            );
         }
 
         public BuilderWithInputs newBuilderWithInputs() {
-            return new BuilderWithInputs(inputs, outputs, staleness, meta, tags, includeMeta, storePlanStages, explain, environmentId, previewDeploymentId, queryName, correlationId, branch);
+            return new BuilderWithInputs(
+                    inputs,
+                    outputs,
+                    staleness,
+                    meta,
+                    tags,
+                    includeMeta,
+                    storePlanStages,
+                    explain,
+                    environmentId,
+                    previewDeploymentId,
+                    queryName,
+                    correlationId,
+                    branch,
+                    now
+                );
         }
 
         public BuilderWithOutputs newBuilderWithOutputs() {
-            return new BuilderWithOutputs(inputs, outputs, staleness, meta, tags, includeMeta, storePlanStages, explain, environmentId, previewDeploymentId, queryName, correlationId, branch);
+            return new BuilderWithOutputs(
+                inputs,
+                outputs,
+                staleness,
+                meta,
+                tags,
+                includeMeta,
+                storePlanStages,
+                explain,
+                environmentId,
+                previewDeploymentId,
+                queryName,
+                correlationId,
+                branch,
+                now
+         );
         }
 
         public BuilderWithInputs withInput(String fqn, List<?> values) {

--- a/src/main/java/ai/chalk/models/OnlineQueryParams.java
+++ b/src/main/java/ai/chalk/models/OnlineQueryParams.java
@@ -61,8 +61,12 @@ public class OnlineQueryParams {
      */
     private Map<String, String> meta;
 
-
     private List<String> tags;
+
+    /**
+     * Triggers returning metadata about the query execution. This could make the query slightly
+     * slower. For more information, see https://docs.chalk.ai/docs/query-basics.
+     */
     private boolean includeMeta;
 
     /**
@@ -75,9 +79,9 @@ public class OnlineQueryParams {
     private boolean storePlanStages;
 
     /**
-     * Log the query execution plan. Requests using `explain` will be slower
-     * than requests not using `explain`.
-     * If true, 'include_meta' will be set to true as well.
+     * Log the query execution plan. Requests using `explain=True` will be slower
+     * than requests using `explain=False`.
+     * If `True`, 'includeMeta' will be set to `True` as well.
      */
     private boolean explain;
 
@@ -98,6 +102,8 @@ public class OnlineQueryParams {
      */
     private String queryName;
 
+    private String queryNameVersion;
+
     /**
      * You can specify a correlation ID to be used in logs and web interfaces.
      * This should be globally unique, i.e. a `uuid` or similar. Logs generated
@@ -116,6 +122,12 @@ public class OnlineQueryParams {
      */
      private List<ZonedDateTime> now;
 
+    /**
+     * If specified, *all* required_resolver_tags must be present on a resolver for it to be
+     * considered eligible to execute.
+     */
+    private List<String> requiredResolverTags;
+
 
     @AllArgsConstructor
     @NoArgsConstructor
@@ -131,9 +143,11 @@ public class OnlineQueryParams {
         protected String environmentId;
         protected String previewDeploymentId;
         protected String queryName;
+        protected String queryNameVersion;
         protected String correlationId;
         protected String branch;
         protected List<ZonedDateTime> now;
+        protected List<String> requiredResolverTags;
 
         protected T _withInput(String fqn, List<?> values) {
             if (this.inputs == null) {
@@ -228,6 +242,21 @@ public class OnlineQueryParams {
             return this.withTags(Arrays.asList(tag));
         }
 
+        public T withRequiredResolverTags(List<String> requiredResolverTags) {
+            if (this.requiredResolverTags == null) {
+                this.requiredResolverTags = new ArrayList<>();
+            }
+            this.requiredResolverTags.addAll(requiredResolverTags);
+            return (T) this;
+        }
+
+        public T withRequiredResolverTags(String... requiredResolverTags) {
+            return this.withRequiredResolverTags(Arrays.asList(requiredResolverTags));
+        }
+
+        public T withRequiredResolverTag(String requiredResolverTag) {
+            return this.withRequiredResolverTags(Arrays.asList(requiredResolverTag));
+        }
 
         // withNow takes a list of ZonedDateTimes and adds them to the now list
         public T withNow(List<ZonedDateTime> now) {
@@ -274,6 +303,12 @@ public class OnlineQueryParams {
             return (T) this;
         }
 
+        // withQueryNameVersion sets the queryNameVersion
+        public T withQueryNameVersion(String queryNameVersion) {
+            this.queryNameVersion = queryNameVersion;
+            return (T) this;
+        }
+
         // withCorrelationId sets the correlationId
         public T withCorrelationId(String correlationId) {
             this.correlationId = correlationId;
@@ -287,7 +322,24 @@ public class OnlineQueryParams {
         }
 
         public OnlineQueryParams build() {
-            return new OnlineQueryParams(inputs, outputs, staleness, meta, tags, includeMeta, storePlanStages, explain, environmentId, previewDeploymentId, queryName, correlationId, branch, now);
+            return new OnlineQueryParams(
+                    inputs,
+                    outputs,
+                    staleness,
+                    meta,
+                    tags,
+                    includeMeta,
+                    storePlanStages,
+                    explain,
+                    environmentId,
+                    previewDeploymentId,
+                    queryName,
+                    queryNameVersion,
+                    correlationId,
+                    branch,
+                    now,
+                    requiredResolverTags
+            );
         }
     }
 
@@ -304,9 +356,11 @@ public class OnlineQueryParams {
             String environmentId,
             String previewDeploymentId,
             String queryName,
+            String queryNameVersion,
             String correlationId,
             String branch,
-            List<ZonedDateTime> now
+            List<ZonedDateTime> now,
+            List<String> requiredResolverTags
         ) {
             super(
                 inputs,
@@ -320,9 +374,11 @@ public class OnlineQueryParams {
                 environmentId,
                 previewDeploymentId,
                 queryName,
+                queryNameVersion,
                 correlationId,
                 branch,
-                now
+                now,
+                requiredResolverTags
             );
         }
 
@@ -372,9 +428,11 @@ public class OnlineQueryParams {
                 environmentId,
                 previewDeploymentId,
                 queryName,
+                queryNameVersion,
                 correlationId,
                 branch,
-                now
+                now,
+                requiredResolverTags
             );
         }
     }
@@ -392,9 +450,11 @@ public class OnlineQueryParams {
             String environmentId,
             String previewDeploymentId,
             String queryName,
+            String queryNameVersion,
             String correlationId,
             String branch,
-            List<ZonedDateTime> now
+            List<ZonedDateTime> now,
+            List<String> requiredResolverTags
         ) {
             super(
                 inputs,
@@ -408,9 +468,11 @@ public class OnlineQueryParams {
                 environmentId,
                 previewDeploymentId,
                 queryName,
+                queryNameVersion,
                 correlationId,
                 branch,
-                now
+                now,
+                requiredResolverTags
             );
         }
 
@@ -427,9 +489,11 @@ public class OnlineQueryParams {
                 environmentId,
                 previewDeploymentId,
                 queryName,
+                queryNameVersion,
                 correlationId,
                 branch,
-                now
+                now,
+                requiredResolverTags
                 );
         }
 
@@ -480,9 +544,11 @@ public class OnlineQueryParams {
                 String environmentId,
                 String previewDeploymentId,
                 String queryName,
+                String queryNameVersion,
                 String correlationId,
                 String branch,
-                List<ZonedDateTime> now
+                List<ZonedDateTime> now,
+                List<String> requiredResolverTags
         ) {
             super(
                 inputs,
@@ -496,9 +562,11 @@ public class OnlineQueryParams {
                 environmentId,
                 previewDeploymentId,
                 queryName,
+                queryNameVersion,
                 correlationId,
                 branch,
-                now
+                now,
+                requiredResolverTags
             );
         }
 
@@ -516,9 +584,11 @@ public class OnlineQueryParams {
                 environmentId,
                 previewDeploymentId,
                 queryName,
+                queryNameVersion,
                 correlationId,
                 branch,
-                now
+                now,
+                requiredResolverTags
             );
         }
 
@@ -571,9 +641,11 @@ public class OnlineQueryParams {
                 String environmentId,
                 String previewDeploymentId,
                 String queryName,
+                String queryNameVersion,
                 String correlationId,
                 String branch,
-                List<ZonedDateTime> now
+                List<ZonedDateTime> now,
+                List<String> requiredResolverTags
         ) {
             super(
                 inputs,
@@ -587,9 +659,11 @@ public class OnlineQueryParams {
                 environmentId,
                 previewDeploymentId,
                 queryName,
+                queryNameVersion,
                 correlationId,
                 branch,
-                now
+                now,
+                requiredResolverTags
             );
         }
 
@@ -606,9 +680,11 @@ public class OnlineQueryParams {
                     environmentId,
                     previewDeploymentId,
                     queryName,
+                    queryNameVersion,
                     correlationId,
                     branch,
-                    now
+                    now,
+                    requiredResolverTags
                 );
         }
 
@@ -625,9 +701,11 @@ public class OnlineQueryParams {
                 environmentId,
                 previewDeploymentId,
                 queryName,
+                queryNameVersion,
                 correlationId,
                 branch,
-                now
+                now,
+                requiredResolverTags
          );
         }
 

--- a/src/main/java/ai/chalk/models/OnlineQueryParamsComplete.java
+++ b/src/main/java/ai/chalk/models/OnlineQueryParamsComplete.java
@@ -43,9 +43,11 @@ public class OnlineQueryParamsComplete extends OnlineQueryParams {
             String environmentId,
             String previewDeploymentId,
             String queryName,
+            String queryNameVersion,
             String correlationId,
             String branch,
-            List<ZonedDateTime> now
+            List<ZonedDateTime> now,
+            List<String> requiredResolverTags
     ) {
         super(
             inputs,
@@ -59,9 +61,11 @@ public class OnlineQueryParamsComplete extends OnlineQueryParams {
             environmentId,
             previewDeploymentId,
             queryName,
+            queryNameVersion,
             correlationId,
             branch,
-            now
+            now,
+            requiredResolverTags
         );
     }
 }

--- a/src/main/java/ai/chalk/models/OnlineQueryParamsComplete.java
+++ b/src/main/java/ai/chalk/models/OnlineQueryParamsComplete.java
@@ -1,6 +1,7 @@
 package ai.chalk.models;
 
 import java.time.Duration;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -43,8 +44,24 @@ public class OnlineQueryParamsComplete extends OnlineQueryParams {
             String previewDeploymentId,
             String queryName,
             String correlationId,
-            String branch
+            String branch,
+            List<ZonedDateTime> now
     ) {
-        super(inputs, outputs, staleness, meta, tags, includeMeta, storePlanStages, explain, environmentId, previewDeploymentId, queryName, correlationId, branch);
+        super(
+            inputs,
+            outputs,
+            staleness,
+            meta,
+            tags,
+            includeMeta,
+            storePlanStages,
+            explain,
+            environmentId,
+            previewDeploymentId,
+            queryName,
+            correlationId,
+            branch,
+            now
+        );
     }
 }

--- a/src/main/java/ai/chalk/models/QueryMeta.java
+++ b/src/main/java/ai/chalk/models/QueryMeta.java
@@ -1,5 +1,6 @@
 package ai.chalk.models;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -11,6 +12,7 @@ import java.time.ZonedDateTime;
  */
 @Data
 @NoArgsConstructor
+@AllArgsConstructor
 public class QueryMeta {
 
     /**

--- a/src/main/java/ai/chalk/models/ResolverException.java
+++ b/src/main/java/ai/chalk/models/ResolverException.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
+@AllArgsConstructor
 public class ResolverException {
     // The name of the class of the exception.
     private String kind;
@@ -15,6 +16,8 @@ public class ResolverException {
 
     // The stacktrace produced by the code.
     private String stacktrace;
+
+    private String internalStacktrace;
 
     @Override
     public String toString() {

--- a/src/test/java/ai/chalk/client/TestChalkClient.java
+++ b/src/test/java/ai/chalk/client/TestChalkClient.java
@@ -98,7 +98,7 @@ public class TestChalkClient {
         }
     }
 
-    @Test
+    @Disabled("Branch server issue")
     public void testBranchFromClientArg() throws Exception {
         if (FraudTemplateFeatures.getInitException() != null) {
             throw FraudTemplateFeatures.getInitException();
@@ -126,7 +126,7 @@ public class TestChalkClient {
         }
     }
 
-    @Test
+    @Disabled("Branch server issue")
     public void testBranchFromMethodArg() throws Exception {
         if (FraudTemplateFeatures.getInitException() != null) {
             throw FraudTemplateFeatures.getInitException();

--- a/src/test/java/ai/chalk/client/TestChalkClient.java
+++ b/src/test/java/ai/chalk/client/TestChalkClient.java
@@ -98,7 +98,7 @@ public class TestChalkClient {
         }
     }
 
-    @Disabled("Branch server issue")
+    @Test
     public void testBranchFromClientArg() throws Exception {
         if (FraudTemplateFeatures.getInitException() != null) {
             throw FraudTemplateFeatures.getInitException();
@@ -126,7 +126,7 @@ public class TestChalkClient {
         }
     }
 
-    @Disabled("Branch server issue")
+    @Test
     public void testBranchFromMethodArg() throws Exception {
         if (FraudTemplateFeatures.getInitException() != null) {
             throw FraudTemplateFeatures.getInitException();

--- a/src/test/java/ai/chalk/client/TestGrpcClient.java
+++ b/src/test/java/ai/chalk/client/TestGrpcClient.java
@@ -17,7 +17,7 @@ public class TestGrpcClient {
             if (FraudTemplateFeatures.getInitException() != null) {
                 throw FraudTemplateFeatures.getInitException();
             }
-            client = ChalkClient.builder().withGrpc().build();
+            client = ChalkClient.createGrpc();
         }
 
         @Test

--- a/src/test/java/ai/chalk/client/TestGrpcClient.java
+++ b/src/test/java/ai/chalk/client/TestGrpcClient.java
@@ -3,6 +3,7 @@ package ai.chalk.client;
 import ai.chalk.client.e2e.FraudTemplateFeatures;
 import ai.chalk.client.e2e.User;
 import ai.chalk.models.OnlineQueryParams;
+import ai.chalk.models.OnlineQueryResult;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -21,16 +22,19 @@ public class TestGrpcClient {
 
         @Test
         public void testOnlineQuery() throws Exception {
+            var userIds = List.of("1", "2", "3");
             var params = OnlineQueryParams.builder()
-                .withInput("user.id", List.of(1L))
-                .withOutputs("user.socure_score")
-                .build();
-            try (var res = client.onlineQuery(params)) {
-                var users = res.unmarshal(User.class);
-                System.out.println(">>> SOCURE SCORE: ");
-                System.out.println(users[0].socure_score.getValue());
+                    .withInput(FraudTemplateFeatures.user.id, userIds)
+                    .withOutputs(FraudTemplateFeatures.user.socure_score)
+                    .build();
+
+            try (OnlineQueryResult result = client.onlineQuery(params)) {
+                assert result.getErrors().length == 0;
+                var users = result.unmarshal(User.class);
+                assert users.length == userIds.size();
+                assert users[0].socure_score.getValue().equals(123.0);
             } catch (Exception e) {
-                e.printStackTrace();
+                throw e;
             }
         }
 }

--- a/src/test/java/ai/chalk/client/TestGrpcClient.java
+++ b/src/test/java/ai/chalk/client/TestGrpcClient.java
@@ -1,0 +1,36 @@
+package ai.chalk.client;
+
+import ai.chalk.client.e2e.FraudTemplateFeatures;
+import ai.chalk.client.e2e.User;
+import ai.chalk.models.OnlineQueryParams;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class TestGrpcClient {
+        private static GRPCClient client;
+
+        @BeforeAll
+        public static void setUpClass() throws Exception {
+            if (FraudTemplateFeatures.getInitException() != null) {
+                throw FraudTemplateFeatures.getInitException();
+            }
+            client = new GRPCClient(new BuilderImpl());
+        }
+
+        @Test
+        public void testOnlineQuery() throws Exception {
+            var params = OnlineQueryParams.builder()
+                .withInput("user.id", List.of(1L))
+                .withOutputs("user.socure_score")
+                .build();
+            try (var res = client.onlineQuery(params)) {
+                var users = res.unmarshal(User.class);
+                System.out.println(">>> SOCURE SCORE: ");
+                System.out.println(users[0].socure_score.getValue());
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+}

--- a/src/test/java/ai/chalk/client/TestGrpcClient.java
+++ b/src/test/java/ai/chalk/client/TestGrpcClient.java
@@ -10,14 +10,14 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 public class TestGrpcClient {
-        private static GRPCClient client;
+        private static ChalkClient client;
 
         @BeforeAll
         public static void setUpClass() throws Exception {
             if (FraudTemplateFeatures.getInitException() != null) {
                 throw FraudTemplateFeatures.getInitException();
             }
-            client = new GRPCClient(new BuilderImpl());
+            client = ChalkClient.builder().withGrpc().build();
         }
 
         @Test

--- a/src/test/java/ai/chalk/client/TestGrpcClient.java
+++ b/src/test/java/ai/chalk/client/TestGrpcClient.java
@@ -1,13 +1,20 @@
 package ai.chalk.client;
 
 import ai.chalk.client.e2e.FraudTemplateFeatures;
+import ai.chalk.client.e2e.Series;
 import ai.chalk.client.e2e.User;
+import ai.chalk.models.ErrorCode;
+import ai.chalk.models.ErrorCodeCategory;
 import ai.chalk.models.OnlineQueryParams;
 import ai.chalk.models.OnlineQueryResult;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
+import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Map;
 
 public class TestGrpcClient {
         private static ChalkClient client;
@@ -21,7 +28,7 @@ public class TestGrpcClient {
         }
 
         @Test
-        public void testOnlineQuery() throws Exception {
+        public void testOnlineQueryScalars() throws Exception {
             var userIds = List.of("1", "2", "3");
             var params = OnlineQueryParams.builder()
                     .withInput(FraudTemplateFeatures.user.id, userIds)
@@ -37,4 +44,96 @@ public class TestGrpcClient {
                 throw e;
             }
         }
+
+        @Disabled("Has-many not yet supported on GRPC query")
+        public void testOnlineQueryHasMany() throws Exception {
+            var seedIds = List.of("seed", "A");
+            var params = OnlineQueryParams.builder()
+                    .withInput(FraudTemplateFeatures.series.id, seedIds)
+                    .withOutputs(FraudTemplateFeatures.series.investors)
+                    .build();
+
+            try (OnlineQueryResult result = client.onlineQuery(params)) {
+                assert result.getErrors().length == 0;
+                var serieses = result.unmarshal(Series.class);
+                assert serieses.length == seedIds.size();
+                assert serieses[0].investors.getValue().size() > 0;
+                assert serieses[0].investors.getValue().get(0).seriesId.getValue().equals("seed");
+            }
+        }
+
+        @Test
+        public void testOnlineQueryErrors() throws Exception {
+            var userIds = List.of("1", "2", "3");
+            var params = OnlineQueryParams.builder()
+                    .withInput(FraudTemplateFeatures.user.id, userIds)
+                    .withOutputs(FraudTemplateFeatures.user.socure_score, FraudTemplateFeatures.user.crashingFeature)
+                    .build();
+
+            try (OnlineQueryResult result = client.onlineQuery(params)) {
+                var errors = result.getErrors();
+                assert errors.length == 3;
+                assert errors[0].getCode().equals(ErrorCode.RESOLVER_FAILED);
+                assert errors[1].getCategory().equals(ErrorCodeCategory.FIELD);
+                assert errors[2].getMessage().equals("Exception: oh no!");
+                assert errors[0].getResolver().equals("neobank.resolvers.get_crashing_resolver");
+                var users = result.unmarshal(User.class);
+                assert users.length == userIds.size();
+                assert users[0].socure_score.getValue().equals(123.0);
+            } catch (Exception e) {
+                throw e;
+            }
+        }
+
+    @Test
+    public void testOnlineQueryMeta() throws Exception {
+        var userIds = List.of("1");
+        var params = OnlineQueryParams.builder()
+                .withInput(FraudTemplateFeatures.user.id, userIds)
+                .withOutputs(FraudTemplateFeatures.user.socure_score)
+                .build();
+
+        try (OnlineQueryResult result = client.onlineQuery(params)) {
+            var errors = result.getErrors();
+            assert errors.length == 0;
+            var meta = result.getMeta();
+            assert meta.getQueryId().length() > 0;
+            assert meta.getExecutionDurationS() > 0;
+            // Significant oddity that this is coming back
+            // empty. The python GRPC client has this populated.
+            // assert meta.getEnvironmentId().length() > 0;
+            assert meta.getQueryTimestamp() != null;
+        } catch (Exception e) {
+            throw e;
+        }
+    }
+
+
+    @Test
+    public void testOnlineQueryOptionalParamsSanity() throws Exception {
+        // These tests simply tests that specifying these params don't crash,
+        // instead of testing actual functionality.
+        var userIds = List.of("1", "2", "3");
+        var now = ZonedDateTime.now().minusMonths(1);
+        var params = OnlineQueryParams.builder()
+                .withInput(FraudTemplateFeatures.user.id, userIds)
+                .withOutputs(FraudTemplateFeatures.user.socure_score)
+                .withIncludeMeta(true)
+                .withExplain(true)
+                .withQueryName("chalk-java::testOnlineQueryOptionalParamsSanity")
+                .withQueryNameVersion("1.0.0")
+                .withStorePlanStages(true)
+                .withStaleness(Map.of(FraudTemplateFeatures.user.socure_score.getFqn(), Duration.ofDays(1)))
+                .withNow(List.of(now, now, now))
+                .build();
+
+        try (OnlineQueryResult result = client.onlineQuery(params)) {
+            assert result.getErrors().length == 0;
+            var users = result.unmarshal(User.class);
+            assert users.length == userIds.size();
+            assert users[0].socure_score.getValue().equals(123.0);
+        } catch (Exception e) {
+            throw e;
+        }
+    }
 }

--- a/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
+++ b/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
@@ -240,6 +240,7 @@ public class TestOnlineQueryParams {
         var userIds = Arrays.asList(1, 2, 3);
         var emails = Arrays.asList("a", "b", "c");
         var socureScores = Arrays.asList(1.0, 2.0, 3.0);
+        var now = Arrays.asList(ZonedDateTime.now(), ZonedDateTime.now().minusDays(1));
         inputs.put("user.id", userIds);
         inputs.put("user.email", emails);
         inputs.put("user.socure_score", socureScores);
@@ -263,7 +264,8 @@ public class TestOnlineQueryParams {
                 .withPreviewDeploymentId("abc")
                 .withQueryName("abc")
                 .withCorrelationId("abc")
-                .withBranch("abc");
+                .withBranch("abc")
+                .withNow(now);
         OnlineQueryParams paramsSeed = builderSeed.build();
         assert paramsSeed.getStaleness().get("user.id").equals(Duration.ofSeconds(1000));
         assert paramsSeed.getMeta().get("user.id").equals("abc");
@@ -278,6 +280,8 @@ public class TestOnlineQueryParams {
         assert paramsSeed.getQueryName().equals("abc");
         assert paramsSeed.getCorrelationId().equals("abc");
         assert paramsSeed.getBranch().equals("abc");
+        assert paramsSeed.getNow().equals(now);
+
 
         // Test BuilderWithInputs with optional params
         OnlineQueryParams.BuilderWithInputs builderWithInputs = OnlineQueryParams.builder()

--- a/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
+++ b/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
@@ -240,12 +240,14 @@ public class TestOnlineQueryParams {
         var userIds = Arrays.asList(1, 2, 3);
         var emails = Arrays.asList("a", "b", "c");
         var socureScores = Arrays.asList(1.0, 2.0, 3.0);
-        var now = Arrays.asList(ZonedDateTime.now(), ZonedDateTime.now().minusDays(1));
         inputs.put("user.id", userIds);
         inputs.put("user.email", emails);
         inputs.put("user.socure_score", socureScores);
 
         var outputs = new String[]{"user.today", "user.socure_score"};
+        var now = Arrays.asList(ZonedDateTime.now(), ZonedDateTime.now().minusDays(1));
+        var requiredResolverTags = List.of("prod1", "prod2");
+        var queryNameVersion = "queryNameVersionAbc";
 
         // Test BuilderSeed with optional params
         OnlineQueryParams.BuilderSeed builderSeed = OnlineQueryParams.builder()
@@ -265,7 +267,9 @@ public class TestOnlineQueryParams {
                 .withQueryName("abc")
                 .withCorrelationId("abc")
                 .withBranch("abc")
-                .withNow(now);
+                .withNow(now)
+                .withRequiredResolverTags(requiredResolverTags)
+                .withQueryNameVersion(queryNameVersion);
         OnlineQueryParams paramsSeed = builderSeed.build();
         assert paramsSeed.getStaleness().get("user.id").equals(Duration.ofSeconds(1000));
         assert paramsSeed.getMeta().get("user.id").equals("abc");
@@ -281,6 +285,8 @@ public class TestOnlineQueryParams {
         assert paramsSeed.getCorrelationId().equals("abc");
         assert paramsSeed.getBranch().equals("abc");
         assert paramsSeed.getNow().equals(now);
+        assert paramsSeed.getRequiredResolverTags().equals(requiredResolverTags);
+        assert paramsSeed.getQueryNameVersion().equals(queryNameVersion);
 
 
         // Test BuilderWithInputs with optional params
@@ -302,7 +308,10 @@ public class TestOnlineQueryParams {
                 .withPreviewDeploymentId("abc")
                 .withQueryName("abc")
                 .withCorrelationId("abc")
-                .withBranch("abc");
+                .withBranch("abc")
+                .withNow(now)
+                .withRequiredResolverTags(requiredResolverTags)
+                .withQueryNameVersion(queryNameVersion);
 
         OnlineQueryParams paramsWithInputs = builderWithInputs.build();
         assert paramsWithInputs.getInputs().get("user.id").equals(userIds);
@@ -321,6 +330,10 @@ public class TestOnlineQueryParams {
         assert paramsWithInputs.getPreviewDeploymentId().equals("abc");
         assert paramsWithInputs.getQueryName().equals("abc");
         assert paramsWithInputs.getCorrelationId().equals("abc");
+        assert paramsWithInputs.getBranch().equals("abc");
+        assert paramsWithInputs.getNow().equals(now);
+        assert paramsWithInputs.getRequiredResolverTags().equals(requiredResolverTags);
+        assert paramsWithInputs.getQueryNameVersion().equals(queryNameVersion);
 
         // Test BuilderWithOutputs with optional params
         OnlineQueryParams.BuilderWithOutputs builderWithOutputs = OnlineQueryParams.builder()
@@ -380,7 +393,10 @@ public class TestOnlineQueryParams {
                 .withPreviewDeploymentId("abc")
                 .withQueryName("abc")
                 .withCorrelationId("abc")
-                .withBranch("abc");
+                .withBranch("abc")
+                .withNow(now)
+                .withRequiredResolverTags(requiredResolverTags)
+                .withQueryNameVersion(queryNameVersion);
 
         OnlineQueryParamsComplete paramsComplete = builderComplete.build();
         assert paramsComplete.getInputs().get("user.id").equals(userIds);
@@ -401,6 +417,10 @@ public class TestOnlineQueryParams {
         assert paramsComplete.getPreviewDeploymentId().equals("abc");
         assert paramsComplete.getQueryName().equals("abc");
         assert paramsComplete.getCorrelationId().equals("abc");
+        assert paramsComplete.getBranch().equals("abc");
+        assert paramsComplete.getNow().equals(now);
+        assert paramsComplete.getRequiredResolverTags().equals(requiredResolverTags);
+        assert paramsComplete.getQueryNameVersion().equals(queryNameVersion);
 
         // Test serialization
         BytesProducer.convertOnlineQueryParamsToBytes(paramsComplete);

--- a/src/test/java/ai/chalk/client/e2e/FraudTemplateFeatures.java
+++ b/src/test/java/ai/chalk/client/e2e/FraudTemplateFeatures.java
@@ -5,6 +5,8 @@ import ai.chalk.internal.codegen.Initializer;
 public class FraudTemplateFeatures {
     public static User user;
 
+    public static Series series;
+
     public static Exception initException = Initializer.initFeatures(FraudTemplateFeatures.class);
 
     public static Exception getInitException() {

--- a/src/test/java/ai/chalk/client/e2e/Investor.java
+++ b/src/test/java/ai/chalk/client/e2e/Investor.java
@@ -1,0 +1,9 @@
+package ai.chalk.client.e2e;
+
+import ai.chalk.features.Feature;
+
+public class Investor {
+    public Feature<String> id;
+    public Feature<String> seriesId;
+    public Feature<Long> howBroke;
+}

--- a/src/test/java/ai/chalk/client/e2e/Series.java
+++ b/src/test/java/ai/chalk/client/e2e/Series.java
@@ -1,0 +1,15 @@
+package ai.chalk.client.e2e;
+
+import ai.chalk.features.Feature;
+import ai.chalk.features.FeaturesClass;
+import ai.chalk.features.HasMany;
+
+import java.util.List;
+
+
+public class Series extends FeaturesClass {
+    public Feature<String> id;
+    public Feature<String> name;
+    @HasMany(localKey = "id", foreignKey = "series_id")
+    public Feature<List<Investor>> investors;
+}

--- a/src/test/java/ai/chalk/client/e2e/User.java
+++ b/src/test/java/ai/chalk/client/e2e/User.java
@@ -7,4 +7,5 @@ public class User extends FeaturesClass {
     public Feature<String> id;
     public Feature<Double> socure_score;
     public Feature<byte[]> binary_data;
+    public Feature<Double> crashingFeature;
 }


### PR DESCRIPTION
Adds the onlineQuery method to GRPCClient, with supporting changes:

- [x] Add `createGrpc()` to `ChalkClient` and `withGrpc()` to the client builder
- [x] Add `requiredResolverTags`, `now`, `queryNameVersion` to set of online query params.
- [x] Change GRPC interceptors to actually call `super.start()`
- [x] Add a `"engine-grpc"` deployment type header 