### PR TITLE
Populate GRPC QueryMeta with trace ID

### DIFF
--- a/src/main/java/ai/chalk/client/GRPCClient.java
+++ b/src/main/java/ai/chalk/client/GRPCClient.java
@@ -217,7 +217,6 @@ public class GRPCClient implements ChalkClient {
             .setResponseOptions(options)
             .build();
 
-        AtomicReference<OnlineQueryBulkResponse> responseRef = new AtomicReference<>();
         AtomicReference<Metadata> trailersRef = new AtomicReference<>();
         OnlineQueryBulkResponse response = this.queryStubWithTrailers(trailersRef).onlineQueryBulk(request);
 

--- a/src/main/java/ai/chalk/client/GrpcSerializer.java
+++ b/src/main/java/ai/chalk/client/GrpcSerializer.java
@@ -56,7 +56,7 @@ public class GrpcSerializer {
         );
     }
 
-    public static ai.chalk.models.QueryMeta toQueryMeta(ai.chalk.protos.chalk.common.v1.OnlineQueryMetadata meta) {
+    public static ai.chalk.models.QueryMeta toQueryMeta(ai.chalk.protos.chalk.common.v1.OnlineQueryMetadata meta, String traceId) {
         ZonedDateTime queryTimestamp = null;
         if (meta.hasQueryTimestamp()) {
             var ts = meta.getQueryTimestamp();
@@ -72,7 +72,8 @@ public class GrpcSerializer {
             meta.getEnvironmentName(),
             meta.getQueryId(),
             queryTimestamp,
-            meta.getQueryHash()
+            meta.getQueryHash(),
+            traceId
         );
     }
 }

--- a/src/main/java/ai/chalk/models/QueryMeta.java
+++ b/src/main/java/ai/chalk/models/QueryMeta.java
@@ -59,4 +59,9 @@ public class QueryMeta {
      * over time as we adjust implementation details.
      */
     private String queryHash;
+
+    /**
+     * Associated trace ID for this query. Instrumental for debugging.
+     */
+    private String traceId;
 }

--- a/src/test/java/ai/chalk/client/TestGrpcClient.java
+++ b/src/test/java/ai/chalk/client/TestGrpcClient.java
@@ -44,6 +44,22 @@ public class TestGrpcClient {
                 throw e;
             }
         }
+        @Test
+        public void testOnlineQueryTraceId() throws Exception {
+            var userIds = List.of("5524");
+            var params = OnlineQueryParams.builder()
+                    .withInput(FraudTemplateFeatures.user.id, userIds)
+                    .withOutputs(FraudTemplateFeatures.user.socure_score)
+                    .build();
+
+            try (OnlineQueryResult result = client.onlineQuery(params)) {
+                assert result.getErrors().length == 0;
+                assert result.getMeta().getTraceId() != null;
+                assert result.getMeta().getTraceId().length() > 0;
+            } catch (Exception e) {
+                throw e;
+            }
+        }
 
         @Disabled("Has-many not yet supported on GRPC query")
         public void testOnlineQueryHasMany() throws Exception {


### PR DESCRIPTION
Populates GRPC online query response with a trace ID that's extracted by a metadata interceptor. 