### PR TITLE
Plug some response parsing leaks

### DIFF
--- a/src/main/java/ai/chalk/client/ChalkClientImpl.java
+++ b/src/main/java/ai/chalk/client/ChalkClientImpl.java
@@ -70,6 +70,7 @@ public class ChalkClientImpl implements ChalkClient {
                 .queryName(params.getQueryName())
                 .build();
 
+        // ignore the warning here, because we don't want to free the memory yet
         return this.handler.sendRequest(request).toResult();
     }
 

--- a/src/main/java/ai/chalk/internal/request/models/OnlineQueryBulkResponse.java
+++ b/src/main/java/ai/chalk/internal/request/models/OnlineQueryBulkResponse.java
@@ -4,21 +4,15 @@ import ai.chalk.exceptions.ChalkException;
 import ai.chalk.exceptions.ClientException;
 import ai.chalk.internal.bytes.BytesConsumer;
 import ai.chalk.models.OnlineQueryResult;
-import lombok.AllArgsConstructor;
 
 import java.util.HashMap;
 import java.util.Map;
 
 
-
-@AllArgsConstructor
-public class OnlineQueryBulkResponse {
-    Map<String, OnlineQueryResultFeather> queryResults;
-
+public record OnlineQueryBulkResponse(Map<String, OnlineQueryResultFeather> queryResults) implements AutoCloseable {
     public static OnlineQueryBulkResponse fromBytes(byte[] bytes) throws ChalkException {
         Map<String, Object> res;
         try {
-
             res = BytesConsumer.unmarshal(bytes);
         } catch (Exception e) {
             throw new ClientException("failed to unmarshal bytes into OnlineQueryBulkResponse", e);
@@ -28,7 +22,6 @@ public class OnlineQueryBulkResponse {
         if (res.containsKey("query_results_bytes")) {
             byte[] queryResultsBytes = (byte[]) res.get("query_results_bytes");
             try {
-
                 Map<String, Object> resultBytesMap = BytesConsumer.unmarshal(queryResultsBytes);
                 for (Map.Entry<String, Object> entry : resultBytesMap.entrySet()) {
                     String key = entry.getKey();
@@ -37,6 +30,9 @@ public class OnlineQueryBulkResponse {
                     resultFeatherMap.put(key, featherResult);
                 }
             } catch (Exception e) {
+                for (var subResult: resultFeatherMap.values()) {
+                    subResult.close();
+                }
                 throw new ClientException("failed to unmarshal bytes into OnlineQueryBulkResponse", e);
             }
         } else {
@@ -52,10 +48,17 @@ public class OnlineQueryBulkResponse {
         }
         OnlineQueryResultFeather internalResult = this.queryResults.get("0");
         return new OnlineQueryResult(
-                internalResult.getScalarData(),
-                internalResult.getGroupsData(),
-                internalResult.getErrors(),
-                internalResult.getMeta()
+                internalResult.scalarData(),
+                internalResult.groupsData(),
+                internalResult.errors(),
+                internalResult.meta()
         );
+    }
+
+    @Override
+    public void close() {
+        for (var subResult: queryResults.values()) {
+            subResult.close();
+        }
     }
 }

--- a/src/main/java/ai/chalk/internal/request/models/OnlineQueryResultFeather.java
+++ b/src/main/java/ai/chalk/internal/request/models/OnlineQueryResultFeather.java
@@ -10,23 +10,21 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.arrow.vector.table.Table;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 
-@Getter
-@AllArgsConstructor
-public class OnlineQueryResultFeather {
-    Boolean hasData;
-    Table scalarData;
-    Map<String, Table> groupsData;
-    ServerError[] errors;
-    QueryMeta meta;
+public record OnlineQueryResultFeather(Boolean hasData, Table scalarData, Map<String, Table> groupsData,
+                                       ServerError[] errors, QueryMeta meta) implements AutoCloseable {
+    private static final Set<String> REQUIRED_KEYS = Set.of(
+            "has_data",
+            "scalar_data",
+            "groups_data",
+            "errors",
+            "meta"
+    );
 
     public static OnlineQueryResultFeather fromBytes(byte[] bytes) throws ChalkException {
         ObjectMapper mapper = new ObjectMapper();
@@ -41,69 +39,18 @@ public class OnlineQueryResultFeather {
             throw new ClientException("failed to unmarshal bytes into OnlineQueryResultFeather", e);
         }
 
-        Object hasDataObj = res.get("has_data");
-        if (hasDataObj == null) {
-            throw new ClientException("missing key 'has_data' in unmarshalled bytes");
+        StringJoiner missingKeys = new StringJoiner(", ");
+        for (var key : REQUIRED_KEYS) {
+            if (!res.containsKey(key)) {
+                missingKeys.add(key);
+            }
         }
-        if (!(hasDataObj instanceof Boolean)) {
-            throw new ClientException("malformed value 'has_data' in unmarshalled bytes");
-        }
-
-        Table scalarData = null;
-        Map<String, Table> groupsData = new HashMap<>();
-        Boolean hasDataBool = (Boolean) hasDataObj;
-        if (hasDataBool) {
-            var scalarDataBytesObj = res.get("scalar_data");
-            if (scalarDataBytesObj == null) {
-                throw new ClientException("missing key 'scalar_data_bytes' in unmarshalled bytes");
-            }
-            if (!(scalarDataBytesObj instanceof byte[])) {
-                throw new ClientException("malformed value 'scalar_data' in unmarshalled bytes");
-            }
-            byte[] scalarDataBytes = (byte[]) scalarDataBytesObj;
-            try {
-                scalarData = FeatherProcessor.convertBytesToTable(scalarDataBytes);
-            } catch (Exception e) {
-                throw new ClientException("failed to convert scalar data bytes to VectorSchemaRoot", e);
-            }
-
-            var groupsDataBytesObj = res.get("groups_data");
-            if (groupsDataBytesObj == null) {
-                throw new ClientException("missing key 'groups_data' in unmarshalled bytes");
-            }
-            if (!(groupsDataBytesObj instanceof byte[])) {
-                throw new ClientException(String.format("malformed value 'groups_data' in unmarshalled bytes - expected `byte[]` found `%s`", groupsDataBytesObj.getClass().getName()));
-            }
-            byte[] groupsDataBytes = (byte[]) groupsDataBytesObj;
-
-            Map<String, Object> groupsDataMap;
-            try {
-                groupsDataMap = BytesConsumer.unmarshal(groupsDataBytes);
-            } catch (Exception e) {
-                throw new ClientException("failed to unmarshal groups data bytes", e);
-            }
-
-            for (Map.Entry<String, Object> entry : groupsDataMap.entrySet()) {
-                String key = entry.getKey();
-                if (!(entry.getValue() instanceof byte[])) {
-                    throw new ClientException(String.format("malformed value 'groups_data' in unmarshalled bytes - expected `byte[]` found `%s`", entry.getValue().getClass().getSimpleName()));
-                }
-                byte[] value = (byte[]) entry.getValue();
-                Table table = null;
-                try {
-                    table = FeatherProcessor.convertBytesToTable(value);
-                } catch (Exception e) {
-                    throw new ClientException(String.format("failed to convert data for has-many feature '%s' bytes to VectorSchemaRoot", key), e);
-                }
-                groupsData.put(key, table);
-            }
+        if (missingKeys.length() != 0) {
+            throw new ClientException("missing keys '[%s]' in unmarshalled bytes".formatted(missingKeys.toString()));
         }
 
         Object errorsObj = res.get("errors");
         ServerError[] errors;
-        if (!(res.containsKey("errors"))) {
-            throw new ClientException("missing key 'errors' in unmarshalled bytes");
-        }
         if (errorsObj == null) {
             errors = null;
         } else if (!(errorsObj instanceof ArrayList<?> errorsStrList)) {
@@ -124,9 +71,6 @@ public class OnlineQueryResultFeather {
         }
         Object metaStrObj = res.get("meta");
         QueryMeta meta;
-        if (!(res.containsKey("meta"))) {
-            throw new ClientException("missing key 'meta' in unmarshalled bytes");
-        }
         if (metaStrObj == null) {
             meta = null;
         } else if (!(metaStrObj instanceof String metaStr)) {
@@ -139,12 +83,74 @@ public class OnlineQueryResultFeather {
             }
         }
 
-        return new OnlineQueryResultFeather(
-                hasDataBool,
-                scalarData,
-                groupsData,
-                errors,
-                meta
-        );
+        Object hasDataObj = res.get("has_data");
+        if (!(hasDataObj instanceof Boolean hasDataBool)) {
+            throw new ClientException("malformed value 'has_data' in unmarshalled bytes");
+        }
+
+        Table scalarData = null;
+        Map<String, Table> groupsData = new HashMap<>();
+        try {
+            if (hasDataBool) {
+                var scalarDataBytesObj = res.get("scalar_data");
+                if (!(scalarDataBytesObj instanceof byte[] scalarDataBytes)) {
+                    throw new ClientException("malformed value 'scalar_data' in unmarshalled bytes");
+                }
+                try {
+                    scalarData = FeatherProcessor.convertBytesToTable(scalarDataBytes);
+                } catch (Exception e) {
+                    throw new ClientException("failed to convert scalar data bytes to VectorSchemaRoot", e);
+                }
+
+                var groupsDataBytesObj = res.get("groups_data");
+                if (!(groupsDataBytesObj instanceof byte[] groupsDataBytes)) {
+                    throw new ClientException(String.format("malformed value 'groups_data' in unmarshalled bytes - expected `byte[]` found `%s`", groupsDataBytesObj.getClass().getName()));
+                }
+
+                Map<String, Object> groupsDataMap;
+                try {
+                    groupsDataMap = BytesConsumer.unmarshal(groupsDataBytes);
+                } catch (Exception e) {
+                    throw new ClientException("failed to unmarshal groups data bytes", e);
+                }
+
+                for (Map.Entry<String, Object> entry : groupsDataMap.entrySet()) {
+                    String key = entry.getKey();
+                    if (!(entry.getValue() instanceof byte[] value)) {
+                        throw new ClientException(String.format("malformed value 'groups_data' in unmarshalled bytes - expected `byte[]` found `%s`", entry.getValue().getClass().getSimpleName()));
+                    }
+                    try {
+                        Table table = FeatherProcessor.convertBytesToTable(value);
+                        groupsData.put(key, table);
+                    } catch (Exception e) {
+                        throw new ClientException(String.format("failed to convert data for has-many feature '%s' bytes to VectorSchemaRoot", key), e);
+                    }
+                }
+            }
+
+            return new OnlineQueryResultFeather(
+                    hasDataBool,
+                    scalarData,
+                    groupsData,
+                    errors,
+                    meta
+            );
+        } catch (Exception e) {
+            if (scalarData != null) scalarData.close();
+            for (Table table : groupsData.values()) {
+                table.close();
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public void close() {
+        if (scalarData != null) {
+            scalarData.close();
+        }
+        for (Table table : groupsData.values()) {
+            table.close();
+        }
     }
 }

--- a/src/main/java/ai/chalk/internal/request/models/OnlineQueryResultFeather.java
+++ b/src/main/java/ai/chalk/internal/request/models/OnlineQueryResultFeather.java
@@ -4,16 +4,19 @@ import ai.chalk.exceptions.ChalkException;
 import ai.chalk.exceptions.ClientException;
 import ai.chalk.exceptions.ServerError;
 import ai.chalk.internal.arrow.FeatherProcessor;
-import ai.chalk.models.QueryMeta;
 import ai.chalk.internal.bytes.BytesConsumer;
+import ai.chalk.models.QueryMeta;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import lombok.Getter;
 import org.apache.arrow.vector.table.Table;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
 
 
 public record OnlineQueryResultFeather(Boolean hasData, Table scalarData, Map<String, Table> groupsData,


### PR DESCRIPTION
Ensure that we free intermediate result tables when an exception occurs during response parsing.