### PR TITLE
[xs] skip all __chalk__ prefixed columns [CHA-4379]

### DIFF
--- a/src/main/java/ai/chalk/internal/Constants.java
+++ b/src/main/java/ai/chalk/internal/Constants.java
@@ -3,5 +3,5 @@ package ai.chalk.internal;
 public class Constants {
     public static String tsFeatureFqn = "__ts__";
     public static String indexFqn = "__index__";
-    public static String metadataPrefix = "__chalk__.__metadata__.";
+    public static String chalkDunderPrefix = "__chalk__.";
 }

--- a/src/main/java/ai/chalk/internal/arrow/Unmarshaller.java
+++ b/src/main/java/ai/chalk/internal/arrow/Unmarshaller.java
@@ -27,7 +27,7 @@ import static org.apache.arrow.vector.types.pojo.ArrowType.ArrowTypeID.LargeList
 
 public class Unmarshaller {
     public static List<String> fqnsToSkip = List.of(Constants.tsFeatureFqn, Constants.indexFqn);
-    public static List<String> prefixToSkip = List.of(Constants.metadataPrefix);
+    public static List<String> prefixToSkip = List.of(Constants.chalkDunderPrefix);
 
     public static <T extends FeaturesClass> T[] unmarshalOnlineQueryResult(OnlineQueryResult result, Class<T> target) throws ClientException {
         try {


### PR DESCRIPTION
GRPC bulk query endpoint will start including more metadata columns, so java client should skip all `__chalk__` prefixes instead of just skipping `__chalk__.__metadata__` when unmarshalling table into feature classes.