### PR TITLE
Publish tagged version that uses arrow-memory-unsafe

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Java client is hosted on Maven Central.
 #### Gradle
 Add the following dependency block to your `build.gradle`. 
 ```java
-implementation 'ai.chalk:chalk-java:0.12.1'
+implementation 'ai.chalk:chalk-java:1.0.0'
 ```
     
 #### Maven
@@ -22,7 +22,7 @@ Add the following dependency block to your `pom.xml`.
     <dependency>
         <groupId>ai.chalk</groupId>
         <artifactId>chalk-java</artifactId>
-        <version>0.12.1</version>
+        <version>1.0.0</version>
     </dependency>
 </dependencies>
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Java client is hosted on Maven Central.
 #### Gradle
 Add the following dependency block to your `build.gradle`. 
 ```java
-implementation 'ai.chalk:chalk-java:1.0.0'
+implementation 'ai.chalk:chalk-java:0.12.1'
 ```
     
 #### Maven
@@ -22,7 +22,7 @@ Add the following dependency block to your `pom.xml`.
     <dependency>
         <groupId>ai.chalk</groupId>
         <artifactId>chalk-java</artifactId>
-        <version>1.0.0</version>
+        <version>0.12.1</version>
     </dependency>
 </dependencies>
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'ai.chalk'
-version '0.12.1'
+version '1.0.0'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'ai.chalk'
-version '1.0.0'
+version '1.0.0-arrow-unsafe'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     api "io.grpc:grpc-stub:${versions.grpcVersion}"
     api "io.grpc:grpc-netty-shaded:${versions.grpcVersion}"
     api "org.apache.arrow:arrow-compression:${versions.arrowVersion}"
-    api "org.apache.arrow:arrow-memory-netty:${versions.arrowVersion}"
+    api "org.apache.arrow:arrow-memory-unsafe:${versions.arrowVersion}"
     api "org.apache.arrow:arrow-vector:${versions.arrowVersion}"
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.7.0'


### PR DESCRIPTION
Use arrow-memory-unsafe instead of arrow-memory-netty for memory management to potentially avoid dependency issues. 