### PR TITLE
add request level header interceptor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,5 @@ jobs:
           CHALK_CLIENT_ID: ${{ secrets.CHALK_CLIENT_ID }}
           CHALK_CLIENT_SECRET: ${{ secrets.CHALK_CLIENT_SECRET }}
           CHALK_ACTIVE_ENVIRONMENT: ${{ secrets.CHALK_ACTIVE_ENVIRONMENT }}
+          STAGING_QA_ENV_ID: ${{ secrets.STAGING_QA_ENV_ID }}
+          STAGING_DEV_ENV_ID: ${{ secrets.STAGING_DEV_ENV_ID }}

--- a/src/main/java/ai/chalk/client/AuthenticatedHeaderClientInterceptor.java
+++ b/src/main/java/ai/chalk/client/AuthenticatedHeaderClientInterceptor.java
@@ -20,8 +20,7 @@ public class AuthenticatedHeaderClientInterceptor implements ClientInterceptor {
     ) {
         this.tokenRefresher = tokenRefresher;
         this.allHeaders = new HashMap<>(Map.of(
-                GrpcHeaders.SERVER_TYPE_KEY, serverType.headerName(),
-//                GrpcHeaders.ENVIRONMENT_ID_KEY, environmentId
+                GrpcHeaders.SERVER_TYPE_KEY, serverType.headerName()
         ));
         for (Map.Entry<String, String> entry : additionalHeaders.entrySet()) {
             this.allHeaders.put(Metadata.Key.of(entry.getKey(), Metadata.ASCII_STRING_MARSHALLER), entry.getValue());

--- a/src/main/java/ai/chalk/client/AuthenticatedHeaderClientInterceptor.java
+++ b/src/main/java/ai/chalk/client/AuthenticatedHeaderClientInterceptor.java
@@ -16,13 +16,12 @@ public class AuthenticatedHeaderClientInterceptor implements ClientInterceptor {
             @NonNull ServerType serverType,
             @NonNull Map<String, String> additionalHeaders,
             @NonNull TokenRefresher tokenRefresher,
-            @NonNull String environmentId,
             @Nullable String deploymentTag
     ) {
         this.tokenRefresher = tokenRefresher;
         this.allHeaders = new HashMap<>(Map.of(
                 GrpcHeaders.SERVER_TYPE_KEY, serverType.headerName(),
-                GrpcHeaders.ENVIRONMENT_ID_KEY, environmentId
+//                GrpcHeaders.ENVIRONMENT_ID_KEY, environmentId
         ));
         for (Map.Entry<String, String> entry : additionalHeaders.entrySet()) {
             this.allHeaders.put(Metadata.Key.of(entry.getKey(), Metadata.ASCII_STRING_MARSHALLER), entry.getValue());

--- a/src/main/java/ai/chalk/client/GRPCClient.java
+++ b/src/main/java/ai/chalk/client/GRPCClient.java
@@ -173,6 +173,10 @@ public class GRPCClient implements ChalkClient, AutoCloseable {
         logger.log(System.Logger.Level.ERROR, "Config printing for GRPC client not yet implemented");
     }
 
+    private RequestHeaderInterceptor getRequestHeaderInterceptor(String environmentId) {
+        return new RequestHeaderInterceptor(environmentId, this.resolvedEnvironmentId);
+    }
+
     public OnlineQueryResult onlineQuery(OnlineQueryParamsComplete params) throws ChalkException {
         byte[] bodyBytes;
         try (
@@ -256,7 +260,7 @@ public class GRPCClient implements ChalkClient, AutoCloseable {
         AtomicReference<Metadata> trailersRef = new AtomicReference<>();
         OnlineQueryBulkResponse response = this.queryStub.withInterceptors(
                 MetadataUtils.newCaptureMetadataInterceptor(new AtomicReference<>(), trailersRef),
-                new RequestHeaderInterceptor(params.getEnvironmentId(), this.resolvedEnvironmentId)
+                this.getRequestHeaderInterceptor(params.getEnvironmentId())
         ).onlineQueryBulk(request);
 
         var meta = GrpcSerializer.toQueryMeta(

--- a/src/main/java/ai/chalk/client/RequestHeaderInterceptor.java
+++ b/src/main/java/ai/chalk/client/RequestHeaderInterceptor.java
@@ -1,0 +1,45 @@
+package ai.chalk.client;
+
+import io.grpc.*;
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A client interceptor that gets tacked on with every request to
+ * allow for request-level header overrides such as environment ID.
+ */
+public class RequestHeaderInterceptor implements ClientInterceptor {
+    public RequestHeaderInterceptor(
+        @Nullable String requestEnvironmentId,
+        @NonNull String clientEnvironmentId
+    ) {
+        this.allHeaders = new HashMap<>();
+        if (requestEnvironmentId != null && !requestEnvironmentId.isEmpty()) {
+            this.allHeaders.put(GrpcHeaders.ENVIRONMENT_ID_KEY, requestEnvironmentId);
+        } else {
+            this.allHeaders.put(GrpcHeaders.ENVIRONMENT_ID_KEY, clientEnvironmentId);
+        }
+    }
+
+    private final @NonNull Map<Metadata.Key<String>, String> allHeaders;
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+            MethodDescriptor<ReqT, RespT> method,
+            CallOptions callOptions, Channel next
+    ) {
+        return new SimpleForwardingClientCall<>(next.newCall(method, callOptions)) {
+            @Override
+            public void start(Listener<RespT> responseListener, Metadata headers) {
+                for (Map.Entry<Metadata.Key<String>, String> entry : allHeaders.entrySet()) {
+                    headers.put(entry.getKey(), entry.getValue());
+                }
+                super.start(responseListener, headers);
+            }
+        };
+    }
+}

--- a/src/test/java/ai/chalk/client/TestAllClients.java
+++ b/src/test/java/ai/chalk/client/TestAllClients.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 
 class TestAllClients {
     private static ChalkClient restClient;
@@ -40,11 +42,11 @@ class TestAllClients {
 
         String qaEnvId = System.getenv().get("STAGING_QA_ENV_ID");
         if (qaEnvId == null) {
-            throw new Exception("STAGING_QA_ENV_ID env var not set");
+            fail("STAGING_QA_ENV_ID env var not set");
         }
         String devEnvId = System.getenv().get("STAGING_DEV_ENV_ID");
         if (devEnvId == null) {
-            throw new Exception("STAGING_DEV_ENV_ID env var not set");
+            fail("STAGING_DEV_ENV_ID env var not set");
         }
 
         for (String envId : Arrays.asList(qaEnvId, devEnvId)) {

--- a/src/test/java/ai/chalk/client/TestAllClients.java
+++ b/src/test/java/ai/chalk/client/TestAllClients.java
@@ -1,0 +1,62 @@
+package ai.chalk.client;
+
+import ai.chalk.client.e2e.FraudTemplateFeatures;
+import ai.chalk.client.e2e.User;
+import ai.chalk.exceptions.ChalkException;
+import ai.chalk.models.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+
+class TestAllClients {
+    private static ChalkClient restClient;
+    private static ChalkClient grpcClient;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        restClient = ChalkClient.create();
+        grpcClient = ChalkClient.createGrpc();
+        if (FraudTemplateFeatures.initException != null) {
+            throw FraudTemplateFeatures.getInitException();
+        }
+    }
+
+
+    /*
+        * Test the request header interceptor by setting an environment ID override
+        * in online query params.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"gRPC", "REST"})
+    public void testRequestHeaderInterceptor(String clientVersion) throws Exception {
+        ChalkClient c = clientVersion.equals("gRPC") ? grpcClient : restClient;
+
+        OnlineQueryParams.BuilderComplete builder = OnlineQueryParams.builder()
+                .withInput(FraudTemplateFeatures.user.id, List.of("1"))
+                .withOutputs(FraudTemplateFeatures.user.environmentId);
+
+        String qaEnvId = System.getenv().get("STAGING_QA_ENV_ID");
+        if (qaEnvId == null) {
+            throw new Exception("STAGING_QA_ENV_ID env var not set");
+        }
+        String devEnvId = System.getenv().get("STAGING_DEV_ENV_ID");
+        if (devEnvId == null) {
+            throw new Exception("STAGING_DEV_ENV_ID env var not set");
+        }
+
+        for (String envId : Arrays.asList(qaEnvId, devEnvId)) {
+            var params = builder.withEnvironmentId(envId).build();
+            try (OnlineQueryResult queryRes = c.onlineQuery(params)) {
+                assert queryRes.getErrors().length == 0;
+                User[] users = queryRes.unmarshal(User.class);
+                assert users.length == 1;
+                assert users[0].environmentId.getValue().equals(envId);
+            }
+        }
+    }
+}

--- a/src/test/java/ai/chalk/client/TestAllClients.java
+++ b/src/test/java/ai/chalk/client/TestAllClients.java
@@ -2,7 +2,6 @@ package ai.chalk.client;
 
 import ai.chalk.client.e2e.FraudTemplateFeatures;
 import ai.chalk.client.e2e.User;
-import ai.chalk.exceptions.ChalkException;
 import ai.chalk.models.*;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -10,7 +9,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 
 class TestAllClients {

--- a/src/test/java/ai/chalk/client/e2e/User.java
+++ b/src/test/java/ai/chalk/client/e2e/User.java
@@ -8,4 +8,5 @@ public class User extends FeaturesClass {
     public Feature<Double> socure_score;
     public Feature<byte[]> binary_data;
     public Feature<Double> crashingFeature;
+    public Feature<String> environmentId;
 }


### PR DESCRIPTION
For gRPC queries, we were previously incorrectly handling the environment ID override at the request level. Here we add a request level header interceptor so that env ID overrides are respected, and add a test. 