### PR TITLE
revert to arrow-memory-netty from unsafe

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Java client is hosted on Maven Central.
 #### Gradle
 Add the following dependency block to your `build.gradle`. 
 ```java
-implementation 'ai.chalk:chalk-java:0.13.0'
+implementation 'ai.chalk:chalk-java:0.14.0'
 ```
     
 #### Maven
@@ -22,7 +22,7 @@ Add the following dependency block to your `pom.xml`.
     <dependency>
         <groupId>ai.chalk</groupId>
         <artifactId>chalk-java</artifactId>
-        <version>0.13.0</version>
+        <version>0.14.0</version>
     </dependency>
 </dependencies>
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'ai.chalk'
-version '0.13.0'
+version '0.14.0'
 
 repositories {
     mavenCentral()
@@ -30,7 +30,7 @@ dependencies {
     api "io.grpc:grpc-stub:${versions.grpcVersion}"
     api "io.grpc:grpc-netty-shaded:${versions.grpcVersion}"
     api "org.apache.arrow:arrow-compression:${versions.arrowVersion}"
-    api "org.apache.arrow:arrow-memory-unsafe:${versions.arrowVersion}"
+    api "org.apache.arrow:arrow-memory-netty:${versions.arrowVersion}"
     api "org.apache.arrow:arrow-vector:${versions.arrowVersion}"
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.7.0'


### PR DESCRIPTION
We published a special debug release in #125  that made the change from `arrow-memory-netty` to `arrow-memory-unsafe`. We did not revert that change before publishing our normal netty releases, causing dependency issues for customers who expect netty. Here we revert that change. 