### PR TITLE
Make unmarshalling into structs faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Java client is hosted on Maven Central.
 #### Gradle
 Add the following dependency block to your `build.gradle`. 
 ```java
-implementation 'ai.chalk:chalk-java:0.14.0'
+implementation 'ai.chalk:chalk-java:0.14.1'
 ```
     
 #### Maven
@@ -22,7 +22,7 @@ Add the following dependency block to your `pom.xml`.
     <dependency>
         <groupId>ai.chalk</groupId>
         <artifactId>chalk-java</artifactId>
-        <version>0.14.0</version>
+        <version>0.14.1</version>
     </dependency>
 </dependencies>
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'ai.chalk'
-version '0.14.0'
+version '0.14.1'
 
 repositories {
     mavenCentral()

--- a/src/main/java/ai/chalk/internal/NamespaceMemoItem.java
+++ b/src/main/java/ai/chalk/internal/NamespaceMemoItem.java
@@ -1,0 +1,14 @@
+package ai.chalk.internal;
+
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class NamespaceMemoItem {
+    public Map<String, List<Integer>> resolvedFieldNameToIndices;
+
+    public NamespaceMemoItem() {
+        resolvedFieldNameToIndices = new HashMap<>();
+    }
+}

--- a/src/main/java/ai/chalk/internal/NamespaceMemoItem.java
+++ b/src/main/java/ai/chalk/internal/NamespaceMemoItem.java
@@ -1,14 +1,17 @@
 package ai.chalk.internal;
 
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class NamespaceMemoItem {
     public Map<String, List<Integer>> resolvedFieldNameToIndices;
+    public List<Boolean> isFieldFeaturesBaseSubclass;
 
     public NamespaceMemoItem() {
         resolvedFieldNameToIndices = new HashMap<>();
+        isFieldFeaturesBaseSubclass = new ArrayList<>();
     }
 }

--- a/src/main/java/ai/chalk/internal/Utils.java
+++ b/src/main/java/ai/chalk/internal/Utils.java
@@ -12,8 +12,13 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.time.temporal.ChronoUnit;
+import java.util.regex.Pattern;
 
 public class Utils {
+    private static final Pattern snakeCase1 = Pattern.compile("(.)([A-Z][a-z]+)");
+    private static final Pattern snakeCase2 = Pattern.compile("__([A-Z])");
+    private static final Pattern snakeCase3 = Pattern.compile("([a-z0-9])([A-Z])");
+
 
     public static String getResolvedName(Field field) {
         var fieldName = chalkpySnakeCase(field.getName());
@@ -55,9 +60,9 @@ public class Utils {
     }
     public static String chalkpySnakeCase(String s) {
         // Aims to be in parity with chalkpy's impl
-        s = s.replaceAll("(.)([A-Z][a-z]+)", "$1_$2");
-        s = s.replaceAll("__([A-Z])", "_$1");
-        s = s.replaceAll("([a-z0-9])([A-Z])", "$1_$2");
+        s = snakeCase1.matcher(s).replaceAll("$1_$2");
+        s = snakeCase2.matcher(s).replaceAll("_$1");
+        s = snakeCase3.matcher(s).replaceAll("$1_$2");
         return s.toLowerCase();
     }
 

--- a/src/main/java/ai/chalk/internal/Utils.java
+++ b/src/main/java/ai/chalk/internal/Utils.java
@@ -21,12 +21,14 @@ public class Utils {
 
 
     public static String getResolvedName(Field field) {
-        var fieldName = chalkpySnakeCase(field.getName());
+        String fieldName;
 
         // If has the Name annotation, use that as the name
         // Otherwise, use the field name snake cased
         if (field.isAnnotationPresent(Name.class)) {
             fieldName = field.getAnnotation(Name.class).value();
+        } else {
+            fieldName = chalkpySnakeCase(field.getName());
         }
 
         if (field.isAnnotationPresent(Versioned.class)) {

--- a/src/main/java/ai/chalk/internal/Utils.java
+++ b/src/main/java/ai/chalk/internal/Utils.java
@@ -51,7 +51,7 @@ public class Utils {
             }
             return fieldName;
         } else if (WindowedFeaturesClass.class.isAssignableFrom(field.getDeclaringClass())) {
-            // Convert average_transactions.bucket_1h to average_transactions__3600s__
+            // Convert bucket_1h to __3600s__
             String durationWithUnitStr = fieldName.substring("bucket_".length());
             String convertedDurationStr = Utils.convertBucketDurationToSeconds(durationWithUnitStr);
             fieldName = String.format("__%s__", convertedDurationStr);

--- a/src/main/java/ai/chalk/internal/Utils.java
+++ b/src/main/java/ai/chalk/internal/Utils.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.time.temporal.ChronoUnit;
 
 public class Utils {
+
     public static String getResolvedName(Field field) {
         // If has the Name annotation, use that as the name
         // Otherwise, use the field name snake cased
@@ -50,8 +51,7 @@ public class Utils {
                 "' does not exist in class " + clazz.getName());
     }
 
-    public static Class<?> getListFeatureInnerType(Field field) throws Exception {
-        Type genericType = field.getGenericType();
+    public static Class<?> getInnerTypeFromListType(Type genericType) throws Exception {
         if (genericType instanceof ParameterizedType) {
             ParameterizedType paramType = (ParameterizedType) genericType;
             Type[] typeArgs = paramType.getActualTypeArguments();
@@ -67,7 +67,19 @@ public class Utils {
                 }
             }
         }
-        throw new Exception("Could not get inner type of field " + field.getName() + " in class " + field.getDeclaringClass().getName());
+        throw new Exception("not a parameterized type");
+    }
+
+    public static Class<?> getInnerTypeFromListField(Field field) throws Exception {
+        Type genericType = field.getGenericType();
+        try {
+            return getInnerTypeFromListType(genericType);
+        } catch (Exception e) {
+            throw new Exception(
+                "Could not get inner type of field " + field.getName() + " in class " + field.getDeclaringClass().getName(),
+                e
+            );
+        }
     }
 
     public static boolean isInteger(String s) {

--- a/src/main/java/ai/chalk/internal/arrow/FeatherProcessor.java
+++ b/src/main/java/ai/chalk/internal/arrow/FeatherProcessor.java
@@ -420,4 +420,9 @@ public class FeatherProcessor {
             return table;
         }
     }
+
+    public static Table inputsToTable(Map<String, List<?>> inputs, BufferAllocator allocator) throws Exception {
+        byte[] bytes = inputsToArrowBytes(inputs, allocator);
+        return convertBytesToTable(bytes, allocator);
+    }
 }

--- a/src/main/java/ai/chalk/internal/arrow/FeatherProcessor.java
+++ b/src/main/java/ai/chalk/internal/arrow/FeatherProcessor.java
@@ -422,7 +422,6 @@ public class FeatherProcessor {
     }
 
     public static Table inputsToTable(Map<String, List<?>> inputs, BufferAllocator allocator) throws Exception {
-        byte[] bytes = inputsToArrowBytes(inputs, allocator);
-        return convertBytesToTable(bytes, allocator);
+        return convertBytesToTable(inputsToArrowBytes(inputs, allocator), allocator);
     }
 }

--- a/src/main/java/ai/chalk/internal/arrow/Unmarshaller.java
+++ b/src/main/java/ai/chalk/internal/arrow/Unmarshaller.java
@@ -48,7 +48,7 @@ public class Unmarshaller {
             String fqn = entry.getKey();
             Table table = entry.getValue();
             Field hasManyField = getFieldFromFqn(targets[0].getClass(), fqn);
-            Class<?> hasManyClass = getListFeatureInnerType(hasManyField);
+            Class<?> hasManyClass = getInnerTypeFromListField(hasManyField);
             if (!hasManyField.isAnnotationPresent(HasMany.class)) {
                 throw new Exception("Field " + fqn + " is not annotated as a has-many field");
             }
@@ -90,11 +90,15 @@ public class Unmarshaller {
         }
     }
 
+
     public static <T extends FeaturesClass> T[] unmarshalTable(Table table, Class<T> target) throws Exception {
         List<T> result = new ArrayList<T>();
 
         // Exists to work around `row.getLargeList` not being available.
         var fqnToLargeListColumnCopy = new HashMap<String, LargeListVector>();
+
+        Field[] fields = Initializer.getFeaturesClassFields(target);
+
         for (Row row : table) {
             T obj = target.getDeclaredConstructor().newInstance();
             Map<String, List<Feature<?>>> featureMap;
@@ -337,7 +341,7 @@ public class Unmarshaller {
                                     Class<?> dataclass;
                                     try {
                                         Field field = Utils.getFieldFromFqn(target, fqn);
-                                        dataclass = Utils.getListFeatureInnerType(field);
+                                        dataclass = Utils.getInnerTypeFromListField(field);
                                     } catch (Exception e) {
                                         throw new Exception("Could not get the inner type of list feature: " + fqn, e);
                                     }

--- a/src/main/java/ai/chalk/internal/arrow/Unmarshaller.java
+++ b/src/main/java/ai/chalk/internal/arrow/Unmarshaller.java
@@ -99,7 +99,7 @@ public class Unmarshaller {
         var fqnToLargeListColumnCopy = new HashMap<String, LargeListVector>();
 
         String namespace = Utils.chalkpySnakeCase(target.getSimpleName());
-        Map<String, NamespaceMemoItem> memo = new HashMap<>();
+        Map<Class<?>, NamespaceMemoItem> memo = new HashMap<>();
         Initializer.buildNamespaceMemo(target, memo, new HashSet<>());
 
         for (Row row : table) {

--- a/src/main/java/ai/chalk/internal/arrow/Unmarshaller.java
+++ b/src/main/java/ai/chalk/internal/arrow/Unmarshaller.java
@@ -6,6 +6,7 @@ import ai.chalk.features.FeaturesClass;
 import ai.chalk.features.HasMany;
 import ai.chalk.features.StructFeaturesClass;
 import ai.chalk.internal.Constants;
+import ai.chalk.internal.NamespaceMemoItem;
 import ai.chalk.internal.Utils;
 import ai.chalk.internal.codegen.Initializer;
 import ai.chalk.models.OnlineQueryResult;
@@ -97,13 +98,15 @@ public class Unmarshaller {
         // Exists to work around `row.getLargeList` not being available.
         var fqnToLargeListColumnCopy = new HashMap<String, LargeListVector>();
 
-        Field[] fields = Initializer.getFeaturesClassFields(target);
+        String namespace = Utils.chalkpySnakeCase(target.getSimpleName());
+        Map<String, NamespaceMemoItem> memo = new HashMap<>();
+        Initializer.buildNamespaceMemo(target, memo, new HashSet<>());
 
         for (Row row : table) {
             T obj = target.getDeclaredConstructor().newInstance();
             Map<String, List<Feature<?>>> featureMap;
             try {
-                featureMap = Initializer.initResult(obj);
+                featureMap = Initializer.initResult(obj, memo, namespace);
             } catch (Exception e) {
                 throw new Exception("Failed to initialize result object", e);
             }
@@ -347,7 +350,8 @@ public class Unmarshaller {
                                     }
 
                                     var dataclassInstance = (StructFeaturesClass) dataclass.getDeclaredConstructor().newInstance();
-                                    var dataclassFeatureMap = Initializer.initResult(dataclassInstance);
+                                    var dataclassNamespace = Utils.chalkpySnakeCase(dataclass.getSimpleName());
+                                    var dataclassFeatureMap = Initializer.initResult(dataclassInstance, memo, dataclassNamespace);
 
                                     for (Map.Entry<String, Object> entry : ((Map<String, Object>) rawObj).entrySet()) {
                                         var dataclassRootFqn = Utils.chalkpySnakeCase(dataclass.getSimpleName());

--- a/src/main/java/ai/chalk/internal/codegen/Initializer.java
+++ b/src/main/java/ai/chalk/internal/codegen/Initializer.java
@@ -67,7 +67,13 @@ public class Initializer {
 
         NamespaceMemoItem nsMemo = memo.get(fc.getClass());
         if (nsMemo == null) {
-            throw new Exception("memo not found for namespace: " + namespace);
+            throw new Exception(
+                String.format(
+                    "memo not found for namespace %s, found keys: %s",
+                    fc.getClass().getSimpleName(),
+                    memo.keySet()
+                )
+            );
         }
 
         for (Map.Entry<String, List<Integer>> entry : nsMemo.resolvedFieldNameToIndices.entrySet()) {
@@ -114,7 +120,13 @@ public class Initializer {
 
             NamespaceMemoItem memoItem = memo.get(castCls);
             if (memoItem == null) {
-                throw new Exception("memo not found for namespace: " + castCls.getSimpleName());
+                throw new Exception(
+                    String.format(
+                        "memo not found for features class %s, found keys: %s",
+                        castCls.getSimpleName(),
+                        memo.keySet()
+                    )
+                );
             }
 
             FeaturesBase fc = (FeaturesBase) f.getType().getConstructor().newInstance();

--- a/src/main/java/ai/chalk/internal/codegen/Initializer.java
+++ b/src/main/java/ai/chalk/internal/codegen/Initializer.java
@@ -158,51 +158,11 @@ public class Initializer {
                     );
                 }
             }
-
-//            for (Field ff : f.getType().getFields()) {
-//                var childFqn = fqn + "." + Utils.getResolvedName(ff);
-//                if (StructFeaturesClass.class.isAssignableFrom(f.getType()) && featureMap == null) {
-//                    // For input features, struct field FQNs end at the last actual feature in the chain.
-//                    // Only override the fqn for StructFeaturesClass children for initing features that are
-//                    // used to specify query inputs. For features that are used to store query outputs, we
-//                    // want a fake FQN (fake being struct fields should not have an FQN).
-//                    childFqn = fqn;
-//                } else if (WindowedFeaturesClass.class.isAssignableFrom(f.getType())) {
-//                    // Convert user.average_transactions.bucket_1h to user.average_transactions__3600__
-//                    String lastPart = Utils.getDotDelimitedLastSection(childFqn);
-//                    String durationWithUnitStr = lastPart.substring("bucket_".length());
-//                    String convertedDurationStr = Utils.convertBucketDurationToSeconds(durationWithUnitStr);
-//                    String replacementPart = String.format("__%s__", convertedDurationStr);
-//                    String partToReplace = "." + lastPart;
-//                    childFqn = childFqn.replace(partToReplace, replacementPart);
-//                }
-//                var obj = init(ff, childFqn, featureMap, seenClassesInChain);
-//                ff.set(fc, obj);
-//            }
             seenClassesInChain.remove(f.getType());
             return fc;
         } else if (f.getType() == Feature.class) {
             // BASE CASE
             Feature<?> feature = (Feature<?>) f.getType().getConstructor().newInstance();
-//            if (f.isAnnotationPresent(Versioned.class)) {
-//                Versioned versionInfo = f.getAnnotation(Versioned.class);
-//                if (versionInfo.defaultVersion() == 0) {
-//                    // Is not base version feature, so we need to strip the `_vN` suffix by splitting on '_'
-//                    String[] parts = fqn.split("_");
-//                    // Parse the digits from the last part of the FQN, which looks something like `v1`
-//                    String versionStr = parts[parts.length - 1].substring(1);
-//                    String baseFqn = String.join("_", Arrays.copyOf(parts, parts.length - 1));
-//                    if (versionStr.equals("1")) {
-//                        // If the version is 1, we don't need to append it to the FQN
-//                        fqn = baseFqn;
-//                    } else {
-//                        fqn = baseFqn + "@" + versionStr;
-//                    }
-//                } else if (versionInfo.defaultVersion() > 1) {
-//                    // Is base version feature, so we need to append the default version to the FQN
-//                    fqn += "@" + versionInfo.defaultVersion();
-//                }
-//            }
             feature.setFqn(fqn);
             if (featureMap != null) {
                 if (featureMap.containsKey(fqn)) {
@@ -269,14 +229,6 @@ public class Initializer {
                     memoItem.resolvedFieldNameToIndices.put(resolvedName, new ArrayList<>());
                 }
                 memoItem.resolvedFieldNameToIndices.get(resolvedName).add(i);
-
-//                if (!(WindowedFeaturesClass.class.isAssignableFrom(cls))) {
-//                    var fqn = namespace + "." + resolvedName;
-//                    if (!memoItem.resolvedFieldNameToIndices.containsKey(fqn)) {
-//                        memoItem.resolvedFieldNameToIndices.put(fqn, new ArrayList<>());
-//                    }
-//                    memoItem.resolvedFieldNameToIndices.get(fqn).add(i);
-//                }
 
                 memoItem.isFieldFeaturesBaseSubclass.add(FeaturesBase.class.isAssignableFrom(fields.get(i).getType()));
                 Class<?> underlyingCls = getUnderlyingClass(fields.get(i).getGenericType());

--- a/src/test/java/ai/chalk/arrow/TestUnmarshaller.java
+++ b/src/test/java/ai/chalk/arrow/TestUnmarshaller.java
@@ -1249,7 +1249,7 @@ public class TestUnmarshaller {
 
 
         var start = System.currentTimeMillis();
-        var users = Unmarshaller.unmarshalTable(table, ArrowUser.class);
+        Unmarshaller.unmarshalTable(table, ArrowUser.class);
         var end = System.currentTimeMillis();
 
         System.out.printf("Bulk unmarshal for %d rows took %d ms\n", userIds.size(), end - start);

--- a/src/test/java/ai/chalk/arrow/TestUnmarshaller.java
+++ b/src/test/java/ai/chalk/arrow/TestUnmarshaller.java
@@ -6,6 +6,7 @@ import ai.chalk.arrow.test_features.VersionedFeaturesClass;
 import ai.chalk.internal.Utils;
 import ai.chalk.internal.arrow.FeatherProcessor;
 import ai.chalk.internal.arrow.Unmarshaller;
+import ai.chalk.models.OnlineQueryParams;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.*;
@@ -1226,6 +1227,32 @@ public class TestUnmarshaller {
         assert namedClasses[0].abc_7d7_efg.getValue().equals("a");
         assert namedClasses[1].abc_7d7_efg.getValue().equals("b");
         assert namedClasses[2].abc_7d7_efg.getValue().equals("c");
+    }
+
+    @Test
+    public void TestBenchmarkBulkUnmarshal() throws Exception {
+        var userIds = new ArrayList<String>();
+        for (var i = 0; i < 3000; i++) {
+            userIds.add(String.valueOf(i));
+        }
+
+        var socureScores = new ArrayList<Double>();
+        for (var i = 0; i < 3000; i++) {
+            socureScores.add(123.0);
+        }
+
+        var inputs = new HashMap<String, List<?>>();
+        inputs.put("arrow_user.id", userIds);
+        inputs.put("arrow_user.favorite_float8", socureScores);
+
+        var table = FeatherProcessor.inputsToTable(inputs, allocator);
+
+
+        var start = System.currentTimeMillis();
+        var users = Unmarshaller.unmarshalTable(table, ArrowUser.class);
+        var end = System.currentTimeMillis();
+
+        System.out.printf("Bulk unmarshal for %d rows took %d ms\n", userIds.size(), end - start);
     }
 
 }

--- a/src/test/java/ai/chalk/arrow/test_features/UnmarshalArrowUser.java
+++ b/src/test/java/ai/chalk/arrow/test_features/UnmarshalArrowUser.java
@@ -1,0 +1,9 @@
+package ai.chalk.arrow.test_features;
+
+import ai.chalk.features.Feature;
+import ai.chalk.features.FeaturesClass;
+
+public class UnmarshalArrowUser extends FeaturesClass {
+    public Feature<String> id;
+    public Feature<Double> favoriteFloat8;
+}

--- a/src/test/java/ai/chalk/arrow/test_features/UnmarshalArrowUser.java
+++ b/src/test/java/ai/chalk/arrow/test_features/UnmarshalArrowUser.java
@@ -1,9 +1,0 @@
-package ai.chalk.arrow.test_features;
-
-import ai.chalk.features.Feature;
-import ai.chalk.features.FeaturesClass;
-
-public class UnmarshalArrowUser extends FeaturesClass {
-    public Feature<String> id;
-    public Feature<Double> favoriteFloat8;
-}

--- a/src/test/java/ai/chalk/internal/TestNamespaceMemo.java
+++ b/src/test/java/ai/chalk/internal/TestNamespaceMemo.java
@@ -26,10 +26,13 @@ public class TestNamespaceMemo {
         var transactionMemo = memo.get("transaction");
         assert transactionMemo.resolvedFieldNameToIndices.get("id").equals(List.of(0));
         assert transactionMemo.resolvedFieldNameToIndices.get("amount").equals(List.of(1));
-        assert transactionMemo.resolvedFieldNameToIndices.get("avgAmount__86400__").equals(List.of(2));
-        assert transactionMemo.resolvedFieldNameToIndices.get("avgAmount__2592000__").equals(List.of(2));
         assert transactionMemo.resolvedFieldNameToIndices.get("name@2").equals(List.of(3, 4));
         assert transactionMemo.resolvedFieldNameToIndices.get("name@3").equals(List.of(5));
+
+        assert memo.containsKey("_windowed_features_1d_30d");
+        var windowedMemo = memo.get("_windowed_features_1d_30d");
+        assert windowedMemo.resolvedFieldNameToIndices.get("__86400__").equals(List.of(0));
+        assert windowedMemo.resolvedFieldNameToIndices.get("__2592000__").equals(List.of(1));
     }
 }
 

--- a/src/test/java/ai/chalk/internal/TestNamespaceMemo.java
+++ b/src/test/java/ai/chalk/internal/TestNamespaceMemo.java
@@ -20,6 +20,7 @@ public class TestNamespaceMemo {
         assert userMemo.resolvedFieldNameToIndices.get("id").equals(List.of(0));
         assert userMemo.resolvedFieldNameToIndices.get("name").equals(List.of(1));
         assert userMemo.resolvedFieldNameToIndices.get("transactions").equals(List.of(2));
+        assert userMemo.isFieldFeaturesBaseSubclass.equals(List.of(false, false, false, false));
 
         assert memo.containsKey(Transaction.class);
         var transactionMemo = memo.get(Transaction.class);
@@ -27,6 +28,7 @@ public class TestNamespaceMemo {
         assert transactionMemo.resolvedFieldNameToIndices.get("amount").equals(List.of(1));
         assert transactionMemo.resolvedFieldNameToIndices.get("name@2").equals(List.of(3, 4));
         assert transactionMemo.resolvedFieldNameToIndices.get("name@3").equals(List.of(5));
+        assert transactionMemo.isFieldFeaturesBaseSubclass.equals(List.of(false, false, true, false, false, false, false));
 
         assert memo.containsKey(_WindowedFeatures_1d_30d.class);
         var windowedMemo = memo.get(_WindowedFeatures_1d_30d.class);

--- a/src/test/java/ai/chalk/internal/TestNamespaceMemo.java
+++ b/src/test/java/ai/chalk/internal/TestNamespaceMemo.java
@@ -1,6 +1,8 @@
 package ai.chalk.internal;
 
+import ai.chalk.internal.test_features.Transaction;
 import ai.chalk.internal.test_features.User;
+import ai.chalk.internal.test_features._WindowedFeatures_1d_30d;
 import org.junit.jupiter.api.Test;
 import ai.chalk.internal.codegen.Initializer;
 
@@ -11,23 +13,23 @@ import java.util.List;
 public class TestNamespaceMemo {
     @Test
     public void TestBuildNamespaceMemo() throws Exception {
-        var memo = new HashMap<String, NamespaceMemoItem>();
+        var memo = new HashMap<Class<?>, NamespaceMemoItem>();
         Initializer.buildNamespaceMemo(User.class, memo, new HashSet<>());
-        assert memo.containsKey("user");
-        var userMemo = memo.get("user");
+        assert memo.containsKey(User.class);
+        var userMemo = memo.get(User.class);
         assert userMemo.resolvedFieldNameToIndices.get("id").equals(List.of(0));
         assert userMemo.resolvedFieldNameToIndices.get("name").equals(List.of(1));
         assert userMemo.resolvedFieldNameToIndices.get("transactions").equals(List.of(2));
 
-        assert memo.containsKey("transaction");
-        var transactionMemo = memo.get("transaction");
+        assert memo.containsKey(Transaction.class);
+        var transactionMemo = memo.get(Transaction.class);
         assert transactionMemo.resolvedFieldNameToIndices.get("id").equals(List.of(0));
         assert transactionMemo.resolvedFieldNameToIndices.get("amount").equals(List.of(1));
         assert transactionMemo.resolvedFieldNameToIndices.get("name@2").equals(List.of(3, 4));
         assert transactionMemo.resolvedFieldNameToIndices.get("name@3").equals(List.of(5));
 
-        assert memo.containsKey("_windowed_features_1d_30d");
-        var windowedMemo = memo.get("_windowed_features_1d_30d");
+        assert memo.containsKey(_WindowedFeatures_1d_30d.class);
+        var windowedMemo = memo.get(_WindowedFeatures_1d_30d.class);
         assert windowedMemo.resolvedFieldNameToIndices.get("__86400__").equals(List.of(0));
         assert windowedMemo.resolvedFieldNameToIndices.get("__2592000__").equals(List.of(1));
     }

--- a/src/test/java/ai/chalk/internal/TestNamespaceMemo.java
+++ b/src/test/java/ai/chalk/internal/TestNamespaceMemo.java
@@ -18,9 +18,6 @@ public class TestNamespaceMemo {
         assert userMemo.resolvedFieldNameToIndices.get("id").equals(List.of(0));
         assert userMemo.resolvedFieldNameToIndices.get("name").equals(List.of(1));
         assert userMemo.resolvedFieldNameToIndices.get("transactions").equals(List.of(2));
-        assert userMemo.resolvedFieldNameToIndices.get("user.id").equals(List.of(0));
-        assert userMemo.resolvedFieldNameToIndices.get("user.name").equals(List.of(1));
-        assert userMemo.resolvedFieldNameToIndices.get("user.transactions").equals(List.of(2));
 
         assert memo.containsKey("transaction");
         var transactionMemo = memo.get("transaction");

--- a/src/test/java/ai/chalk/internal/TestNamespaceMemo.java
+++ b/src/test/java/ai/chalk/internal/TestNamespaceMemo.java
@@ -1,0 +1,36 @@
+package ai.chalk.internal;
+
+import ai.chalk.internal.test_features.User;
+import org.junit.jupiter.api.Test;
+import ai.chalk.internal.codegen.Initializer;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+
+public class TestNamespaceMemo {
+    @Test
+    public void TestBuildNamespaceMemo() throws Exception {
+        var memo = new HashMap<String, NamespaceMemoItem>();
+        Initializer.buildNamespaceMemo(User.class, memo, new HashSet<>());
+        assert memo.containsKey("user");
+        var userMemo = memo.get("user");
+        assert userMemo.resolvedFieldNameToIndices.get("id").equals(List.of(0));
+        assert userMemo.resolvedFieldNameToIndices.get("name").equals(List.of(1));
+        assert userMemo.resolvedFieldNameToIndices.get("transactions").equals(List.of(2));
+        assert userMemo.resolvedFieldNameToIndices.get("user.id").equals(List.of(0));
+        assert userMemo.resolvedFieldNameToIndices.get("user.name").equals(List.of(1));
+        assert userMemo.resolvedFieldNameToIndices.get("user.transactions").equals(List.of(2));
+
+        assert memo.containsKey("transaction");
+        var transactionMemo = memo.get("transaction");
+        assert transactionMemo.resolvedFieldNameToIndices.get("id").equals(List.of(0));
+        assert transactionMemo.resolvedFieldNameToIndices.get("amount").equals(List.of(1));
+        assert transactionMemo.resolvedFieldNameToIndices.get("avgAmount__86400__").equals(List.of(2));
+        assert transactionMemo.resolvedFieldNameToIndices.get("avgAmount__2592000__").equals(List.of(2));
+        assert transactionMemo.resolvedFieldNameToIndices.get("name@2").equals(List.of(3, 4));
+        assert transactionMemo.resolvedFieldNameToIndices.get("name@3").equals(List.of(5));
+    }
+}
+
+

--- a/src/test/java/ai/chalk/internal/test_features/Transaction.java
+++ b/src/test/java/ai/chalk/internal/test_features/Transaction.java
@@ -1,0 +1,16 @@
+package ai.chalk.internal.test_features;
+
+import ai.chalk.features.FeaturesClass;
+import ai.chalk.features.Versioned;
+
+public class Transaction extends FeaturesClass {
+    public String id;
+    public double amount;
+    public _WindowedFeatures_1d_30d avgAmount;
+    @Versioned( defaultVersion = 2 )
+    public String name;
+    @Versioned
+    public String nameV2;
+    @Versioned
+    public String nameV3;
+}

--- a/src/test/java/ai/chalk/internal/test_features/User.java
+++ b/src/test/java/ai/chalk/internal/test_features/User.java
@@ -1,0 +1,12 @@
+package ai.chalk.internal.test_features;
+
+import ai.chalk.features.Feature;
+import ai.chalk.features.FeaturesClass;
+
+import java.util.List;
+
+public class User extends FeaturesClass {
+    public Feature<String> id;
+    public Feature<String> name;
+    public Feature<List<Transaction>> transactions;
+}

--- a/src/test/java/ai/chalk/internal/test_features/_WindowedFeatures_1d_30d.java
+++ b/src/test/java/ai/chalk/internal/test_features/_WindowedFeatures_1d_30d.java
@@ -1,0 +1,12 @@
+package ai.chalk.internal.test_features;
+
+import ai.chalk.features.Name;
+import ai.chalk.features.WindowedFeaturesClass;
+
+public class _WindowedFeatures_1d_30d extends WindowedFeaturesClass {
+    @Name("bucket_1d")
+    public double bucket1d;
+
+    @Name("bucket_30d")
+    public double bucket30d;
+}


### PR DESCRIPTION
`TestBenchmarkBulkUnmarshal()` goes from ~500ms -> ~190ms

Main optimizations for unmarshalling:
- [x] memoize resolved field name to avoid calling snake casing repeatedly
- [x] memoize whether a field is a `FeaturesBase` subclass

Smaller fish:
- [x] Made snake case regex compilation static
- [x] Remove usages of Array.stream

TODO optimizations (separate PR)
- [ ] Build a deserialization scope so that we don't construct `Feature` object nor populate `featureMap` for features that are not in scope. In scope means feature is included in output.  