### PR TITLE
[ci] use latest tag instead of GITHUB_REF

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,8 @@ jobs:
           distribution: 'oracle'
           cache: gradle
 
-      - name: Extract Version from GitHub Tag
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+      - name: Extract Latest Version from Git Tags
+        run: echo "VERSION=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
 
       - name: Update README.md and gradle.properties with release version
         run: |


### PR DESCRIPTION
So that we can trigger the release action on any branch instead of having to trigger via a github release. This is helpful when the initial action fails, and we want to re-trigger on main. 