### PR TITLE
fix named query builder

### DIFF
--- a/src/main/java/ai/chalk/client/GRPCClient.java
+++ b/src/main/java/ai/chalk/client/GRPCClient.java
@@ -202,8 +202,13 @@ public class GRPCClient implements ChalkClient, AutoCloseable {
             throw new ClientException("Failed to serialize OnlineQueryParams", e);
         }
 
+        List<String> resolvedOutputs = params.getOutputs();
+        if (resolvedOutputs == null) {
+            resolvedOutputs = new ArrayList<>();
+        }
+
         List<OutputExpr> outputs = new ArrayList<>();
-        for (var output : params.getOutputs()) {
+        for (var output : resolvedOutputs) {
             outputs.add(OutputExpr.newBuilder().setFeatureFqn(output).build());
         }
 

--- a/src/main/java/ai/chalk/internal/bytes/BytesProducer.java
+++ b/src/main/java/ai/chalk/internal/bytes/BytesProducer.java
@@ -10,7 +10,9 @@ import java.io.DataOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static ai.chalk.internal.Utils.toChalkDuration;
@@ -23,8 +25,9 @@ public class BytesProducer {
         if (params.getInputs() == null) {
             throw new Exception("`inputs` cannot be null - please use OnlineQueryParams.builder().input(...).build()");
         }
-        if (params.getOutputs() == null) {
-            throw new Exception("`outputs` cannot be null - please use OnlineQueryParams.builder().outputs(...).build()");
+        List<String> resolvedOutputs = params.getOutputs();
+        if (resolvedOutputs == null) {
+            resolvedOutputs = new ArrayList<>();
         }
         try {
             arrowBytes = FeatherProcessor.inputsToArrowBytes(params.getInputs(), allocator);
@@ -33,7 +36,7 @@ public class BytesProducer {
         }
 
         Map<String, Object> jsonHeader = new HashMap<>();
-        jsonHeader.put("outputs", params.getOutputs());
+        jsonHeader.put("outputs", resolvedOutputs);
         jsonHeader.put("include_meta", params.isIncludeMeta());
         jsonHeader.put("store_plan_stages", params.isStorePlanStages());
         jsonHeader.put("explain", params.isExplain());
@@ -54,6 +57,9 @@ public class BytesProducer {
         }
         if (params.getQueryName() != null) {
             jsonHeader.put("query_name", params.getQueryName());
+        }
+        if (params.getQueryNameVersion() != null) {
+            jsonHeader.put("query_name_version", params.getQueryNameVersion());
         }
         if (params.getStaleness() != null) {
             var staleness = new HashMap<String, String>();

--- a/src/main/java/ai/chalk/internal/bytes/BytesProducer.java
+++ b/src/main/java/ai/chalk/internal/bytes/BytesProducer.java
@@ -78,9 +78,6 @@ public class BytesProducer {
         if (params.getNow() != null) {
             jsonHeader.put("now", params.getNow());
         }
-        if (params.getRequiredResolverTags() != null) {
-            jsonHeader.put("required_resolver_tags", params.getRequiredResolverTags());
-        }
 
         return jsonHeader;
     }

--- a/src/main/java/ai/chalk/internal/bytes/BytesProducer.java
+++ b/src/main/java/ai/chalk/internal/bytes/BytesProducer.java
@@ -20,8 +20,7 @@ import static ai.chalk.internal.Utils.toChalkDuration;
 
 public class BytesProducer {
     private static final ObjectMapper mapper = new ObjectMapper()
-            .registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule())
-            .configure(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+            .registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
 
     /**
      * Builds a JSON header map from OnlineQueryParams object

--- a/src/main/java/ai/chalk/internal/bytes/BytesProducer.java
+++ b/src/main/java/ai/chalk/internal/bytes/BytesProducer.java
@@ -1,6 +1,7 @@
 package ai.chalk.internal.bytes;
 
 import ai.chalk.internal.arrow.FeatherProcessor;
+import ai.chalk.models.OnlineQueryParams;
 import ai.chalk.models.OnlineQueryParamsComplete;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.arrow.memory.BufferAllocator;
@@ -18,21 +19,21 @@ import java.util.Map;
 import static ai.chalk.internal.Utils.toChalkDuration;
 
 public class BytesProducer {
-    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper mapper = new ObjectMapper()
+            .registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule())
+            .configure(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
 
-    public static byte[] convertOnlineQueryParamsToBytes(OnlineQueryParamsComplete params, BufferAllocator allocator) throws Exception {
-        byte[] arrowBytes;
-        if (params.getInputs() == null) {
-            throw new Exception("`inputs` cannot be null - please use OnlineQueryParams.builder().input(...).build()");
-        }
+    /**
+     * Builds a JSON header map from OnlineQueryParams object
+     * This method extracts all the fields from params into a map that will be serialized as JSON
+     * 
+     * @param params The query parameters object
+     * @return A map containing all the fields from params that should be included in the JSON header
+     */
+    public static Map<String, Object> buildJsonHeader(OnlineQueryParams params) {
         List<String> resolvedOutputs = params.getOutputs();
         if (resolvedOutputs == null) {
             resolvedOutputs = new ArrayList<>();
-        }
-        try {
-            arrowBytes = FeatherProcessor.inputsToArrowBytes(params.getInputs(), allocator);
-        } catch (Exception e) {
-            throw new Exception("failed to convert inputs to Arrow bytes", e);
         }
 
         Map<String, Object> jsonHeader = new HashMap<>();
@@ -74,6 +75,28 @@ public class BytesProducer {
         if (params.getPlannerOptions() != null) {
             jsonHeader.put("planner_options", params.getPlannerOptions());
         }
+        if (params.getNow() != null) {
+            jsonHeader.put("now", params.getNow());
+        }
+        if (params.getRequiredResolverTags() != null) {
+            jsonHeader.put("required_resolver_tags", params.getRequiredResolverTags());
+        }
+
+        return jsonHeader;
+    }
+
+    public static byte[] convertOnlineQueryParamsToBytes(OnlineQueryParamsComplete params, BufferAllocator allocator) throws Exception {
+        byte[] arrowBytes;
+        if (params.getInputs() == null) {
+            throw new Exception("`inputs` cannot be null - please use OnlineQueryParams.builder().input(...).build()");
+        }
+        try {
+            arrowBytes = FeatherProcessor.inputsToArrowBytes(params.getInputs(), allocator);
+        } catch (Exception e) {
+            throw new Exception("failed to convert inputs to Arrow bytes", e);
+        }
+
+        Map<String, Object> jsonHeader = buildJsonHeader(params);
 
         ByteArrayOutputStream result = new ByteArrayOutputStream();
         DataOutputStream ioWriter = new DataOutputStream(result);
@@ -85,7 +108,7 @@ public class BytesProducer {
 
         // Placeholder for the sizes
         byte[] placeholder = new byte[8];
-        byte[] jsonBytes = new ObjectMapper().writeValueAsBytes(jsonHeader);
+        byte[] jsonBytes = mapper.writeValueAsBytes(jsonHeader);
 
         // Write json header
         ioWriter.write(placeholder);

--- a/src/main/java/ai/chalk/models/OnlineQueryParams.java
+++ b/src/main/java/ai/chalk/models/OnlineQueryParams.java
@@ -332,7 +332,7 @@ public class OnlineQueryParams {
         }
 
         // withQueryName sets the queryName
-        public T withQueryName(String queryName) {
+        public T _withQueryName(String queryName) {
             this.queryName = queryName;
             return (T) this;
         }
@@ -577,6 +577,10 @@ public class OnlineQueryParams {
         public BuilderComplete withOutputs(FeaturesBase... outputs) {
             return this.newBuilderComplete()._withOutputs(outputs);
         }
+
+        public BuilderComplete withQueryName(String queryName) {
+            return this.newBuilderComplete()._withQueryName(queryName);
+        }
     }
 
     public static class BuilderWithOutputs extends Builder<BuilderWithOutputs> {
@@ -678,6 +682,10 @@ public class OnlineQueryParams {
 
         public BuilderWithOutputs withOutputs(FeaturesBase... outputs) {
             return this._withOutputs(outputs);
+        }
+
+        public BuilderWithOutputs withQueryName(String queryName) {
+            return this._withQueryName(queryName);
         }
     }
 
@@ -807,6 +815,10 @@ public class OnlineQueryParams {
 
         public BuilderWithOutputs withOutputs(StructFeaturesClass... outputs) {
             return newBuilderWithOutputs().withOutputs(outputs);
+        }
+
+        public BuilderWithOutputs withQueryName(String queryName) {
+            return newBuilderWithOutputs().withQueryName(queryName);
         }
     }
 

--- a/src/test/java/ai/chalk/client/TestChalkClient.java
+++ b/src/test/java/ai/chalk/client/TestChalkClient.java
@@ -53,6 +53,31 @@ public class TestChalkClient {
     }
 
     @Test
+    public void testNamedQuery() throws Exception {
+        if (FraudTemplateFeatures.getInitException() != null) {
+            throw FraudTemplateFeatures.getInitException();
+        }
+
+        String[] userIds = new String[3];
+        for (int i = 0; i < userIds.length; i++) {
+            userIds[i] = String.format("%d", i);
+        }
+
+        OnlineQueryParamsComplete params = OnlineQueryParams.builder()
+                .withInput(FraudTemplateFeatures.user.id, userIds)
+                .withQueryName("user_socure_score")
+                .withQueryNameVersion("1.0.0")
+                .build();
+
+        try (OnlineQueryResult result = client.onlineQuery(params)) {
+            assert result.getErrors().length == 0;
+            var users = result.unmarshal(User.class);
+            assert users.length == userIds.length;
+            assert users[0].socure_score.getValue().equals(123.0);
+        }
+    }
+
+    @Test
     public void testBinaryInput() throws Exception {
         if (FraudTemplateFeatures.getInitException() != null) {
             throw FraudTemplateFeatures.getInitException();

--- a/src/test/java/ai/chalk/client/TestChalkClient.java
+++ b/src/test/java/ai/chalk/client/TestChalkClient.java
@@ -52,30 +52,6 @@ public class TestChalkClient {
         }
     }
 
-    @Test
-    public void testNamedQuery() throws Exception {
-        if (FraudTemplateFeatures.getInitException() != null) {
-            throw FraudTemplateFeatures.getInitException();
-        }
-
-        String[] userIds = new String[3];
-        for (int i = 0; i < userIds.length; i++) {
-            userIds[i] = String.format("%d", i);
-        }
-
-        OnlineQueryParamsComplete params = OnlineQueryParams.builder()
-                .withInput(FraudTemplateFeatures.user.id, userIds)
-                .withQueryName("user_socure_score")
-                .withQueryNameVersion("1.0.0")
-                .build();
-
-        try (OnlineQueryResult result = client.onlineQuery(params)) {
-            assert result.getErrors().length == 0;
-            var users = result.unmarshal(User.class);
-            assert users.length == userIds.length;
-            assert users[0].socure_score.getValue().equals(123.0);
-        }
-    }
 
     @Test
     public void testBinaryInput() throws Exception {

--- a/src/test/java/ai/chalk/client/TestGrpcClient.java
+++ b/src/test/java/ai/chalk/client/TestGrpcClient.java
@@ -139,12 +139,12 @@ public class TestGrpcClient {
         var now = ZonedDateTime.now().minusMonths(1);
         var params = OnlineQueryParams.builder()
                 .withInput(FraudTemplateFeatures.user.id, userIds)
+                .withQueryName("chalk-java::testOnlineQueryOptionalParamsSanity")
+                .withQueryNameVersion("1.0.0")
                 .withOutputs(FraudTemplateFeatures.user.socure_score)
                 // TODO: CHA-4791
                 // .withIncludeMeta(true)
                 // .withExplain(true)
-                .withQueryName("chalk-java::testOnlineQueryOptionalParamsSanity")
-                .withQueryNameVersion("1.0.0")
                 .withStorePlanStages(true)
                 .withStaleness(Map.of(FraudTemplateFeatures.user.socure_score.getFqn(), Duration.ofDays(1)))
                 .withNow(List.of(now, now, now))

--- a/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
+++ b/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
@@ -444,7 +444,7 @@ public class TestOnlineQueryParams extends AllocatorTest {
         assert paramsComplete.getPlannerOptions().equals(plannerOptions);
 
         // Test serialization
-        byte[] paramsCompleteBytes = BytesProducer.convertOnlineQueryParamsToBytes(paramsComplete, allocator);
+        BytesProducer.convertOnlineQueryParamsToBytes(paramsComplete, allocator);
     }
 
     @Test

--- a/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
+++ b/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
@@ -322,7 +322,8 @@ public class TestOnlineQueryParams extends AllocatorTest {
         assertTrue(jsonHeaderSeed.containsKey("staleness"));
         assertTrue(jsonHeaderSeed.containsKey("tags"));
         assertEquals(now, jsonHeaderSeed.get("now"));
-        assertEquals(requiredResolverTags, jsonHeaderSeed.get("required_resolver_tags"));
+        // Required resolver tags is not yet implemented in the query feather endpoint
+        //        assertEquals(requiredResolverTags, jsonHeaderSeed.get("required_resolver_tags"));
         assertEquals(plannerOptions, jsonHeaderSeed.get("planner_options"));
 
         // Test BuilderWithInputs with optional params
@@ -386,7 +387,8 @@ public class TestOnlineQueryParams extends AllocatorTest {
         assertTrue(jsonHeaderWithInputs.containsKey("staleness"));
         assertTrue(jsonHeaderWithInputs.containsKey("tags"));
         assertEquals(now, jsonHeaderWithInputs.get("now"));
-        assertEquals(requiredResolverTags, jsonHeaderWithInputs.get("required_resolver_tags"));
+        // Required resolver tags is not yet implemented in the query feather endpoint
+        //        assertEquals(requiredResolverTags, jsonHeaderWithInputs.get("required_resolver_tags"));
         assertEquals(plannerOptions, jsonHeaderWithInputs.get("planner_options"));
 
         // Test BuilderWithOutputs with optional params
@@ -492,7 +494,8 @@ public class TestOnlineQueryParams extends AllocatorTest {
         assert paramsComplete.getCorrelationId().equals("abc");
         assert paramsComplete.getBranch().equals("abc");
         assert paramsComplete.getNow().equals(now);
-        assert paramsComplete.getRequiredResolverTags().equals(requiredResolverTags);
+        // Required resolver tags is not yet implemented in the query feather endpoint
+        //        assert paramsComplete.getRequiredResolverTags().equals(requiredResolverTags);
         assert paramsComplete.getQueryNameVersion().equals(queryNameVersion);
         assert paramsComplete.getPlannerOptions().equals(plannerOptions);
 
@@ -515,7 +518,8 @@ public class TestOnlineQueryParams extends AllocatorTest {
         assertTrue(jsonHeader.containsKey("staleness"));
         assertTrue(jsonHeader.containsKey("tags"));
         assertEquals(now, jsonHeader.get("now"));
-        assertEquals(requiredResolverTags, jsonHeader.get("required_resolver_tags"));
+        // Required resolver tags is not yet implemented in the query feather endpoint
+        // assertEquals(requiredResolverTags, jsonHeader.get("required_resolver_tags"));
         assertEquals(plannerOptions, jsonHeader.get("planner_options"));
     }
 

--- a/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
+++ b/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
@@ -10,10 +10,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.*;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
+import java.util.Map;
 
 public class TestOnlineQueryParams extends AllocatorTest {
     public static boolean jsonCompare(String expected, String actual) throws Exception {
@@ -304,6 +307,23 @@ public class TestOnlineQueryParams extends AllocatorTest {
         assert paramsSeed.getQueryNameVersion().equals(queryNameVersion);
         assert paramsSeed.getPlannerOptions().equals(plannerOptions);
 
+        // Verify the JSON header for BuilderSeed
+        Map<String, Object> jsonHeaderSeed = BytesProducer.buildJsonHeader(paramsSeed);
+        assertTrue(jsonHeaderSeed.containsKey("outputs"));
+        assertEquals(true, jsonHeaderSeed.get("include_meta"));
+        assertEquals(true, jsonHeaderSeed.get("store_plan_stages"));
+        assertEquals(true, jsonHeaderSeed.get("explain"));
+        assertEquals("abc", jsonHeaderSeed.get("branch"));
+        assertEquals("abc", jsonHeaderSeed.get("correlation_id"));
+        assertEquals("abc", jsonHeaderSeed.get("environment_id"));
+        assertEquals("abc", jsonHeaderSeed.get("deployment_id"));
+        assertEquals(queryNameVersion, jsonHeaderSeed.get("query_name_version"));
+        assertTrue(jsonHeaderSeed.containsKey("meta"));
+        assertTrue(jsonHeaderSeed.containsKey("staleness"));
+        assertTrue(jsonHeaderSeed.containsKey("tags"));
+        assertEquals(now, jsonHeaderSeed.get("now"));
+        assertEquals(requiredResolverTags, jsonHeaderSeed.get("required_resolver_tags"));
+        assertEquals(plannerOptions, jsonHeaderSeed.get("planner_options"));
 
         // Test BuilderWithInputs with optional params
         OnlineQueryParams.BuilderWithInputs builderWithInputs = OnlineQueryParams.builder()
@@ -351,6 +371,24 @@ public class TestOnlineQueryParams extends AllocatorTest {
         assert paramsWithInputs.getQueryNameVersion().equals(queryNameVersion);
         assert paramsWithInputs.getPlannerOptions().equals(plannerOptions);
 
+        // Verify the JSON header for BuilderWithInputs
+        Map<String, Object> jsonHeaderWithInputs = BytesProducer.buildJsonHeader(paramsWithInputs);
+        assertTrue(jsonHeaderWithInputs.containsKey("outputs"));
+        assertEquals(true, jsonHeaderWithInputs.get("include_meta"));
+        assertEquals(true, jsonHeaderWithInputs.get("store_plan_stages"));
+        assertEquals(true, jsonHeaderWithInputs.get("explain"));
+        assertEquals("abc", jsonHeaderWithInputs.get("branch"));
+        assertEquals("abc", jsonHeaderWithInputs.get("correlation_id"));
+        assertEquals("abc", jsonHeaderWithInputs.get("environment_id"));
+        assertEquals("abc", jsonHeaderWithInputs.get("deployment_id"));
+        assertEquals(queryNameVersion, jsonHeaderWithInputs.get("query_name_version"));
+        assertTrue(jsonHeaderWithInputs.containsKey("meta"));
+        assertTrue(jsonHeaderWithInputs.containsKey("staleness"));
+        assertTrue(jsonHeaderWithInputs.containsKey("tags"));
+        assertEquals(now, jsonHeaderWithInputs.get("now"));
+        assertEquals(requiredResolverTags, jsonHeaderWithInputs.get("required_resolver_tags"));
+        assertEquals(plannerOptions, jsonHeaderWithInputs.get("planner_options"));
+
         // Test BuilderWithOutputs with optional params
         OnlineQueryParams.BuilderWithOutputs builderWithOutputs = OnlineQueryParams.builder()
                 .withOutputs(outputs)
@@ -391,6 +429,21 @@ public class TestOnlineQueryParams extends AllocatorTest {
         assert paramsWithOutputs.getCorrelationId().equals("abc");
         assert paramsWithOutputs.getPlannerOptions().equals(plannerOptions);
 
+        // Verify the JSON header for BuilderWithOutputs
+        Map<String, Object> jsonHeaderWithOutputs = BytesProducer.buildJsonHeader(paramsWithOutputs);
+        assertEquals(outputs.length, ((List<?>) jsonHeaderWithOutputs.get("outputs")).size());
+        assertEquals(true, jsonHeaderWithOutputs.get("include_meta"));
+        assertEquals(true, jsonHeaderWithOutputs.get("store_plan_stages"));
+        assertEquals(true, jsonHeaderWithOutputs.get("explain"));
+        assertEquals("abc", jsonHeaderWithOutputs.get("branch"));
+        assertEquals("abc", jsonHeaderWithOutputs.get("correlation_id"));
+        assertEquals("abc", jsonHeaderWithOutputs.get("environment_id"));
+        assertEquals("abc", jsonHeaderWithOutputs.get("deployment_id"));
+        assertEquals("abc", jsonHeaderWithOutputs.get("query_name"));
+        assertTrue(jsonHeaderWithOutputs.containsKey("meta"));
+        assertTrue(jsonHeaderWithOutputs.containsKey("staleness"));
+        assertTrue(jsonHeaderWithOutputs.containsKey("tags"));
+        assertEquals(plannerOptions, jsonHeaderWithOutputs.get("planner_options"));
 
         // Test BuilderComplete with optional params
         OnlineQueryParams.BuilderComplete builderComplete = OnlineQueryParams.builder()
@@ -443,8 +496,27 @@ public class TestOnlineQueryParams extends AllocatorTest {
         assert paramsComplete.getQueryNameVersion().equals(queryNameVersion);
         assert paramsComplete.getPlannerOptions().equals(plannerOptions);
 
-        // Test serialization
+        // Test serialization and verify JSON header for BuilderComplete
         BytesProducer.convertOnlineQueryParamsToBytes(paramsComplete, allocator);
+        
+        // Verify the JSON header contains all the optional parameters
+        Map<String, Object> jsonHeader = BytesProducer.buildJsonHeader(paramsComplete);
+        assertEquals(outputs.length, ((List<?>) jsonHeader.get("outputs")).size());
+        assertEquals(true, jsonHeader.get("include_meta"));
+        assertEquals(true, jsonHeader.get("store_plan_stages"));
+        assertEquals(true, jsonHeader.get("explain"));
+        assertEquals("abc", jsonHeader.get("branch"));
+        assertEquals("abc", jsonHeader.get("correlation_id"));
+        assertEquals("abc", jsonHeader.get("environment_id"));
+        assertEquals("abc", jsonHeader.get("deployment_id"));
+        assertEquals("abc", jsonHeader.get("query_name"));
+        assertEquals(queryNameVersion, jsonHeader.get("query_name_version"));
+        assertTrue(jsonHeader.containsKey("meta"));
+        assertTrue(jsonHeader.containsKey("staleness"));
+        assertTrue(jsonHeader.containsKey("tags"));
+        assertEquals(now, jsonHeader.get("now"));
+        assertEquals(requiredResolverTags, jsonHeader.get("required_resolver_tags"));
+        assertEquals(plannerOptions, jsonHeader.get("planner_options"));
     }
 
     @Test

--- a/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
+++ b/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
@@ -1,6 +1,7 @@
 package ai.chalk.client;
 
 import ai.chalk.internal.arrow.FeatherProcessor;
+import ai.chalk.internal.bytes.BytesConsumer;
 import ai.chalk.internal.bytes.BytesProducer;
 import ai.chalk.models.OnlineQueryParams;
 import ai.chalk.client.features.InitFeaturesTestFeatures;
@@ -279,7 +280,6 @@ public class TestOnlineQueryParams extends AllocatorTest {
                 .withExplain(true)
                 .withEnvironmentId("abc")
                 .withPreviewDeploymentId("abc")
-                .withQueryName("abc")
                 .withCorrelationId("abc")
                 .withBranch("abc")
                 .withNow(now)
@@ -297,7 +297,6 @@ public class TestOnlineQueryParams extends AllocatorTest {
         assert paramsSeed.isExplain();
         assert paramsSeed.getEnvironmentId().equals("abc");
         assert paramsSeed.getPreviewDeploymentId().equals("abc");
-        assert paramsSeed.getQueryName().equals("abc");
         assert paramsSeed.getCorrelationId().equals("abc");
         assert paramsSeed.getBranch().equals("abc");
         assert paramsSeed.getNow().equals(now);
@@ -323,7 +322,6 @@ public class TestOnlineQueryParams extends AllocatorTest {
                 .withExplain(true)
                 .withEnvironmentId("abc")
                 .withPreviewDeploymentId("abc")
-                .withQueryName("abc")
                 .withCorrelationId("abc")
                 .withBranch("abc")
                 .withNow(now)
@@ -346,7 +344,6 @@ public class TestOnlineQueryParams extends AllocatorTest {
         assert paramsWithInputs.isExplain();
         assert paramsWithInputs.getEnvironmentId().equals("abc");
         assert paramsWithInputs.getPreviewDeploymentId().equals("abc");
-        assert paramsWithInputs.getQueryName().equals("abc");
         assert paramsWithInputs.getCorrelationId().equals("abc");
         assert paramsWithInputs.getBranch().equals("abc");
         assert paramsWithInputs.getNow().equals(now);
@@ -398,6 +395,7 @@ public class TestOnlineQueryParams extends AllocatorTest {
         // Test BuilderComplete with optional params
         OnlineQueryParams.BuilderComplete builderComplete = OnlineQueryParams.builder()
                 .withInputs(inputs)
+                .withQueryName("abc")
                 .withOutputs(outputs)
                 .withStaleness(new HashMap<>() {{
                     put("user.id", Duration.ofSeconds(1000));
@@ -413,7 +411,6 @@ public class TestOnlineQueryParams extends AllocatorTest {
                 .withExplain(true)
                 .withEnvironmentId("abc")
                 .withPreviewDeploymentId("abc")
-                .withQueryName("abc")
                 .withCorrelationId("abc")
                 .withBranch("abc")
                 .withNow(now)
@@ -447,7 +444,7 @@ public class TestOnlineQueryParams extends AllocatorTest {
         assert paramsComplete.getPlannerOptions().equals(plannerOptions);
 
         // Test serialization
-        BytesProducer.convertOnlineQueryParamsToBytes(paramsComplete, allocator);
+        byte[] paramsCompleteBytes = BytesProducer.convertOnlineQueryParamsToBytes(paramsComplete, allocator);
     }
 
     @Test


### PR DESCRIPTION
Treat query name just like outputs, and return a OnlineQueryParamsComplete accordingly