### PR TITLE
fix withQueryName back compat

### DIFF
--- a/src/main/java/ai/chalk/models/OnlineQueryParams.java
+++ b/src/main/java/ai/chalk/models/OnlineQueryParams.java
@@ -455,6 +455,10 @@ public class OnlineQueryParams {
             return this._withOutputs(outputs);
         }
 
+        public BuilderComplete withQueryName(String queryName) {
+            return this._withQueryName(queryName);
+        }
+
         public OnlineQueryParamsComplete build() {
             return new OnlineQueryParamsComplete(
                 inputs,

--- a/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
+++ b/src/test/java/ai/chalk/client/TestOnlineQueryParams.java
@@ -450,8 +450,8 @@ public class TestOnlineQueryParams extends AllocatorTest {
         // Test BuilderComplete with optional params
         OnlineQueryParams.BuilderComplete builderComplete = OnlineQueryParams.builder()
                 .withInputs(inputs)
-                .withQueryName("abc")
                 .withOutputs(outputs)
+                .withQueryName("abc")
                 .withStaleness(new HashMap<>() {{
                     put("user.id", Duration.ofSeconds(1000));
                 }})


### PR DESCRIPTION
this ensures maximal back-compat, otherwise we can't call `withQueryName` on a `BuilderComplete`