### PR TITLE
Add self-contained ai.chalk:chalk-java-shaded artifact (version-independent)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,10 +157,10 @@ mavenPublishing {
 }
 
 // Second coordinate: ai.chalk:chalk-java-shaded. Identical classes to chalk-java, but every
-// third-party dependency is relocated into ai.chalk.shaded.* (see the shadowJar block). Its POM is
-// intentionally DEPENDENCY-FREE — the deps live inside the jar — so a consumer pinned to older
-// protobuf/grpc/jackson/arrow/netty never gets a conflicting transitive pulled in. Built as a manual
-// publication (not `from components.java`), so no dependencies are written to the POM.
+// third-party dependency is relocated into ai.chalk.shaded.* (see the shadowJar block). Its POM
+// declares only slf4j-api (a non-relocatable logging facade) — every other dep lives inside the jar,
+// so a consumer pinned to older protobuf/grpc/jackson/arrow/netty never gets a conflicting transitive
+// pulled in. Built as a manual publication (not `from components.java`) to keep the POM minimal.
 publishing {
     publications {
         shaded(MavenPublication) {
@@ -168,8 +168,20 @@ publishing {
             // Publish the shaded jar as the module's main artifact (strip the 'shaded' classifier).
             artifact(tasks.shadowJar) { classifier = null }
             // POM name/license/scm/developers are applied to all publications by the vanniktech
-            // mavenPublishing block below. No <dependencies> are declared here on purpose — every
-            // third-party dep is bundled + relocated inside the jar.
+            // mavenPublishing block below. The ONLY declared dependency is slf4j-api: bundled
+            // arrow/netty classes reference org.slf4j, but it is not relocatable (it's a logging
+            // facade that must bind to the runtime's logging). Declaring it guarantees the class is
+            // present for any consumer; in a Flink runtime, Flink parent-first-loads org.slf4j, so
+            // its own version always wins regardless of what we declare. Everything else is bundled +
+            // relocated inside the jar, so no other (conflict-prone) dependency is declared.
+            pom.withXml {
+                def deps = asNode().appendNode('dependencies')
+                def slf4j = deps.appendNode('dependency')
+                slf4j.appendNode('groupId', 'org.slf4j')
+                slf4j.appendNode('artifactId', 'slf4j-api')
+                slf4j.appendNode('version', '2.0.9')
+                slf4j.appendNode('scope', 'runtime')
+            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id "signing"
     id "io.github.gradle-nexus.publish-plugin" version "1.3.0"
     id 'com.vanniktech.maven.publish' version '0.30.0'
+    id 'com.gradleup.shadow' version '8.3.5'
 }
 
 group 'ai.chalk'
@@ -45,6 +46,35 @@ dependencies {
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.7.0'
     testImplementation 'org.slf4j:slf4j-simple:2.0.9'
+}
+
+// Self-contained "shaded" jar: relocates ALL third-party deps into ai.chalk.shaded.* so the artifact
+// is immune to whatever versions a consumer (or their Flink runtime) pins. Flink is compileOnly, so
+// it is not bundled (stays provided by the cluster). Publish as the `shaded` classifier.
+shadowJar {
+    archiveClassifier = 'shaded'
+    mergeServiceFiles()   // rewrite META-INF/services (grpc providers, jackson, etc.) to shaded names
+
+    // slf4j-api is the logging facade — let the runtime (Flink) own it exclusively, so there's no
+    // facade version skew (1.x vs 2.x binding). chalk-java's org.slf4j refs bind to the runtime's.
+    dependencies { exclude(dependency('org.slf4j:slf4j-api')) }
+
+    relocate 'com.google', 'ai.chalk.shaded.google'          // protobuf, guava, gson, flatbuffers, api-protos
+    relocate 'io.grpc', 'ai.chalk.shaded.grpc'               // incl. grpc-netty-shaded
+    relocate 'io.netty', 'ai.chalk.shaded.netty'             // arrow-memory-netty (pure JVM here)
+    relocate 'io.perfmark', 'ai.chalk.shaded.perfmark'
+    relocate 'com.fasterxml.jackson', 'ai.chalk.shaded.jackson'
+    relocate 'org.apache.arrow', 'ai.chalk.shaded.arrow'
+    relocate 'org.apache.commons', 'ai.chalk.shaded.commons' // codec, io, compress, lang3
+    relocate 'org.yaml.snakeyaml', 'ai.chalk.shaded.snakeyaml'
+    relocate 'org.checkerframework', 'ai.chalk.shaded.checkerframework'
+    relocate 'org.codehaus.mojo', 'ai.chalk.shaded.mojo'
+    // Intentionally NOT relocated:
+    //   ai.chalk.*            -> the public API (consumers import these)
+    //   org.slf4j             -> logging facade; must bind to the runtime's logging
+    //   javax.annotation      -> standard annotations, no conflict
+    //   com.github.luben      -> zstd-jni: native JNI, relocating its package breaks the .so binding
+    //   org.apache.flink.*    -> provided by the cluster (compileOnly, not bundled)
 }
 
 test {
@@ -122,6 +152,24 @@ mavenPublishing {
             connection = 'scm:git:git://github.com/chalk-ai/chalk-java.git'
             developerConnection = 'scm:git:ssh://github.com:chalk-ai/chalk-java.git'
             url = 'https://github.com/chalk-ai/chalk-java/'
+        }
+    }
+}
+
+// Second coordinate: ai.chalk:chalk-java-shaded. Identical classes to chalk-java, but every
+// third-party dependency is relocated into ai.chalk.shaded.* (see the shadowJar block). Its POM is
+// intentionally DEPENDENCY-FREE — the deps live inside the jar — so a consumer pinned to older
+// protobuf/grpc/jackson/arrow/netty never gets a conflicting transitive pulled in. Built as a manual
+// publication (not `from components.java`), so no dependencies are written to the POM.
+publishing {
+    publications {
+        shaded(MavenPublication) {
+            artifactId = 'chalk-java-shaded'
+            // Publish the shaded jar as the module's main artifact (strip the 'shaded' classifier).
+            artifact(tasks.shadowJar) { classifier = null }
+            // POM name/license/scm/developers are applied to all publications by the vanniktech
+            // mavenPublishing block below. No <dependencies> are declared here on purpose — every
+            // third-party dep is bundled + relocated inside the jar.
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds a second published coordinate, **`ai.chalk:chalk-java-shaded`** — the same client + Flink connector as `chalk-java`, but with **every third-party dependency relocated** into `ai.chalk.shaded.*`. It's self-contained, so it works on **any** classpath regardless of what protobuf/grpc/jackson/arrow/netty versions a consumer (or their Flink/Spark runtime) pins.

## Why

A consumer pinned below our dependency versions hits linkage errors — e.g. a client on **protobuf 3.19** gets:
```
java.lang.NoClassDefFoundError: com/google/protobuf/MapFieldReflectionAccessor
    at ai.chalk.protos.chalk.server.v1.AuthServiceGrpc.getGetTokenMethod(...)
```
`MapFieldReflectionAccessor` is a protobuf 3.25 class our generated stubs need, but the older protobuf on their classpath wins. We can't ask every consumer to change their pinned versions, and we can't shade protobuf into the *main* `chalk-java` (its query API exposes `ai.chalk.protos.*` types). So this ships a separate, fully-relocated artifact for exactly these conflict-prone environments (Flink connector use is the driver — its public API exposes zero third-party types).

## What changed

- `com.gradleup.shadow` plugin + a `shadowJar` that relocates `com.google` (protobuf/guava/gson/flatbuffers/api-protos), `io.grpc`, `io.netty`, `io.perfmark`, `com.fasterxml.jackson`, `org.apache.arrow`, `org.apache.commons`, `org.yaml.snakeyaml` → `ai.chalk.shaded.*`, with `mergeServiceFiles()` so gRPC's `ServiceLoader` providers are rewritten too.
- A `chalk-java-shaded` `MavenPublication` with a **dependency-free POM** (built manually, not `from components.java`) — critical: if the POM declared the deps, consumers would pull protobuf 3.25 transitively and re-hit the conflict.
- **Not relocated (intentional):** `org.slf4j` (excluded — logging facade binds to the runtime), `javax.annotation`, `com.github.luben` (zstd-jni — native JNI, relocation breaks the `.so` symbol binding), `org.apache.flink` (compileOnly, provided by the cluster).

## Verification (local)

Ran the **exact failing call** from the crash with **protobuf 3.19.0** on the classpath:

| Classpath | Result |
| --- | --- |
| **shaded** jar + protobuf 3.19 | ✅ PASS — `getGetTokenMethod()` returns `ai.chalk.shaded.grpc.MethodDescriptor` |
| unshaded chalk-java + protobuf 3.19 | ❌ reproduces the `MapFieldReflectionAccessor` crash (proves the test is real) |

Also verified: `com/google/protobuf` fully relocated (0 unshaded), `ai.chalk.protos`/`ai.chalk.flink` untouched, gRPC `ServiceLoader` files rewritten to shaded provider names, and the generated `chalk-java-shaded` POM is dependency-free with clean metadata.

## Consume

```kotlin
implementation("ai.chalk:chalk-java-shaded:<version>")   // instead of chalk-java, for pinned-version envs
```

## Needs a maintainer eye before release

I could verify the artifact + POM locally (`shadowJar`, `generatePomFile`, `publishToMavenLocal`), but **not** the actual Central Portal upload of this second coordinate — that runs in CI with signing secrets. Please confirm on first release that `publishAllPublicationsToMavenCentral` picks up the `shaded` publication (vanniktech is single-artifact-oriented; the manual publication is signed by `signAllPublications()` and should be bundled, but it's worth watching the first publish).
