### PR TITLE
Fix publish/sign task ordering for shaded publication (unblocks release)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -185,3 +185,13 @@ publishing {
         }
     }
 }
+
+// With two publications (maven + shaded), both sign tasks write their .asc into build/libs, and each
+// publish task reads from build/libs — so Gradle's strict validation flags an implicit dependency
+// between publish and the *other* publication's sign task and fails the build. Order all publish
+// tasks after all sign tasks to make the dependency explicit.
+import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
+import org.gradle.plugins.signing.Sign
+tasks.withType(AbstractPublishToMaven).configureEach {
+    mustRunAfter(tasks.withType(Sign))
+}


### PR DESCRIPTION
## Problem

The 1.3.3 release publish **failed**:
```
Task ':signShadedPublication' FAILED
  ':publishMavenPublicationToMavenCentralRepository' uses this output of task
  ':signShadedPublication' ('chalk-java-1.3.3-shaded.jar.asc') without declaring
  an explicit or implicit dependency.
```
Adding the second (`shaded`) publication in #200 introduced a second `Sign` task. Both sign tasks write their `.asc` into `build/libs`, and each publish task reads from `build/libs` — so Gradle's strict task-dependency validation flags an implicit dependency between a publish task and the *other* publication's sign task, and aborts the build. Nothing was released (staging aborted), so `chalk-java`/`chalk-java-shaded` 1.3.3 are not on Central.

## Fix

Order all publish tasks after all sign tasks so the dependency is explicit (the standard fix for this multi-publication + signing validation error):
```groovy
tasks.withType(AbstractPublishToMaven).configureEach {
    mustRunAfter(tasks.withType(Sign))
}
```

## Verification (local, with a throwaway signing key)

- **Reproduced** the exact failure on the current build (`publishToMavenLocal` → same `implicit dependency` error on `signShadedPublication`).
- **With the fix**: `BUILD SUCCESSFUL`, task order is now `signMaven → signShaded → publishMaven → publishShaded`, both publications produced and signed, no validation error.

## After merge

Re-cut the 1.3.3 release off the fixed main (the previous `release/1.3.3` branch/#203 has the buggy build and never published). Then `chalk-java-shaded:1.3.3` publishes for the first time.
